### PR TITLE
docs: Pinned --target install command + auto-bumped README version

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](CONTRIBUTING.md)
-[![GitHub last commit](https://img.shields.io/github/last-commit/DevSecNinja/gpt-prompts)](https://github.com/DevSecNinja/gpt-prompts/commits/main)
-[![GitHub contributors](https://img.shields.io/github/contributors/DevSecNinja/gpt-prompts)](https://github.com/DevSecNinja/gpt-prompts/graphs/contributors)
+[![GitHub last commit](https://img.shields.io/github/last-commit/DevSecNinja/ai-toolkit)](https://github.com/DevSecNinja/ai-toolkit/commits/main)
+[![GitHub contributors](https://img.shields.io/github/contributors/DevSecNinja/ai-toolkit)](https://github.com/DevSecNinja/ai-toolkit/graphs/contributors)
 
 ## 📚 What's This?
 
@@ -54,16 +54,26 @@ An organized, reusable toolkit of AI primitives to supercharge your AI coding ha
 ## 📦 Install via APM
 
 This toolkit is an [APM (Agent Package Manager)](https://microsoft.github.io/apm/)
-**producer**. Install every primitive as native commands in your AI harness
-(GitHub Copilot, Claude Code, Cursor, OpenCode, Gemini, Windsurf):
+**producer**. Install its primitives as native commands in your AI harness
+(GitHub Copilot, Claude Code, Cursor, OpenCode, Gemini, Windsurf).
 
+Pin a released version and pick your harness with `--target`:
+
+<!-- x-release-please-start-version -->
 ```bash
-apm install DevSecNinja/ai-toolkit
+apm install DevSecNinja/ai-toolkit#v0.1.0 --target copilot
 ```
+<!-- x-release-please-end -->
 
-> `apm install` resolves by GitHub repo name, so this requires the repository to
-> be named `ai-toolkit`. See the [APM Producer Guide](/docs/apm.md) for how these
-> primitives are authored, produced and consumed.
+> `apm install` resolves by GitHub repo name (`ai-toolkit`). Omit `#v0.1.0` to
+> install from the latest default branch, and omit `--target` to install into
+> every detected harness.
+
+Run `apm targets` to list the supported harnesses you can pass to `--target`
+(e.g. `copilot`, `claude`, `cursor`, `opencode`, `gemini`, `windsurf`).
+
+See the [APM Producer Guide](/docs/apm.md) for how these primitives are authored,
+produced and consumed.
 
 ## 🤝 Contributing
 

--- a/docs/apm.md
+++ b/docs/apm.md
@@ -61,16 +61,19 @@ automatically whenever a primitive changes and commits the refreshed index.
 
 ## 📥 How to consume these primitives
 
+Pin a released version and pick your harness with `--target`:
+
 ```bash
-apm install DevSecNinja/ai-toolkit
+apm install DevSecNinja/ai-toolkit#v0.1.0 --target copilot
 ```
 
-> **Note:** `apm install <owner>/<repo>` resolves by **GitHub repository name**.
-> For `DevSecNinja/ai-toolkit` to work, the GitHub repo must be named
-> `ai-toolkit` (matching `apm.yml`'s `name`). Until the repo is renamed, install
-> from the current repository name.
+> Omit `#vX.Y.Z` to install from the latest default branch, and omit `--target`
+> to install into every detected harness. Run `apm targets` to list the
+> supported harnesses you can pass to `--target` (`copilot`, `claude`, `cursor`,
+> `opencode`, `gemini`, `windsurf`). `apm install` resolves by **GitHub
+> repository name** (`ai-toolkit`, matching `apm.yml`'s `name`).
 
-`apm install` deploys each prompt to every detected harness, keeping its
+`apm install` deploys each prompt to the targeted harness(es), keeping its
 `<category>-<name>` command name:
 
 | Harness | Where the prompt lands | How to invoke |

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -18,6 +18,10 @@
         {
           "type": "generic",
           "path": "apm.yml"
+        },
+        {
+          "type": "generic",
+          "path": "README.md"
         }
       ]
     }


### PR DESCRIPTION
## What

Updates the install instructions to match real usage and makes the README version self-bumping.

- **README install example** now shows the pinned, targeted form you actually use:
  ```bash
  apm install DevSecNinja/ai-toolkit#v0.1.0 --target copilot
  ```
- Documents **`apm targets`** for discovering harnesses beyond `copilot` (`claude`, `cursor`, `opencode`, `gemini`, `windsurf`), and notes that omitting `--target` installs into all detected harnesses.
- **Auto-bumping:** the pinned command is wrapped in `release-please` version block markers, and `README.md` is added to the config's `extra-files`. So when release-please cuts a release, the `#vX.Y.Z` in the README is bumped alongside `apm.yml`.
- Mirrors the guidance in `docs/apm.md` and fixes the now-stale `gpt-prompts` badge URLs → `ai-toolkit`.

## Notes

- `release-please-config.json` `extra-files` now lists both `apm.yml` and `README.md` (both `type: generic`). The README block uses `<!-- x-release-please-start-version -->` / `<!-- x-release-please-end -->` markers placed outside the code fence, so they don't render but still scope the bump.
- The auto-generated INDEX block is untouched by this mechanism.
- Validation + index generation pass locally.