### PR TITLE
feat: add org conventions as an APM instruction primitive

### DIFF
--- a/.apm/instructions/devsecninja-conventions.instructions.md
+++ b/.apm/instructions/devsecninja-conventions.instructions.md
@@ -1,0 +1,50 @@
+---
+description: "DevSecNinja org-wide engineering conventions for AI agents: Conventional-Commit PR titles, pre-PR checks, docs, and no force-push."
+applyTo: "**"
+---
+
+# DevSecNinja Engineering Conventions
+
+Org-wide rules for every DevSecNinja repository. A repository's own
+`.github/copilot-instructions.md` may add repo-specific detail on top of these.
+
+## Pull requests
+
+- PR titles MUST follow [Conventional Commits](https://www.conventionalcommits.org):
+  `type(scope): description`. PRs are **squash-merged**, so the PR title becomes
+  the commit on `main` and feeds release-please's changelog and version bump —
+  get it right even if the in-PR commits are informal.
+  - Types: `feat`, `fix`, `docs`, `ci`, `chore`, `refactor`, `perf`, `test`.
+  - Use `feat!:` / `fix!:` (or a `BREAKING CHANGE:` footer) for breaking changes.
+    A new required input to a centralized/reusable workflow IS breaking, so
+    Renovate does not automerge a change that breaks downstream CI.
+- Run lint and tests before opening a PR and fix anything that fails:
+  `mise exec -- lefthook run pre-commit` plus the repo's test command. Never open
+  a PR with known-failing checks.
+- Update documentation in the same PR as the code it describes — READMEs, inline
+  docs, and generated indexes. Don't defer docs to a follow-up.
+- Keep PRs focused: one logical change per PR.
+- Never force-push to `main` or any shared/protected branch. All changes land via
+  PR through normal CI; branch protection is always respected.
+
+## Coding standards
+
+- Commit messages follow Conventional Commits (same types as above). In-PR
+  commits may be informal; the PR title is authoritative.
+- YAML: 2-space indent, start with `---`, format with yamlfmt, lint with yamllint.
+- Markdown: format with dprint, 4-space indent.
+- Shell: Bash dialect, 4-space indent, lint with shellcheck, format with shfmt.
+- GitHub Actions: pin action refs to full commit SHAs with a version comment,
+  e.g. `uses: actions/checkout@<sha> # v4.2.0`. Add a `# renovate:` comment where
+  applicable so Renovate can bump it.
+- Reusable workflows in `DevSecNinja/.github` MUST NOT default package/tool
+  version inputs — declare them `required: true` so the caller owns the version.
+- Security: never commit plaintext secrets. Use SOPS, Vault, or GitHub Secrets.
+
+## Tooling and files
+
+- Tools are managed by [mise](https://mise.jdx.dev/) (`.mise.toml`); run them via
+  `mise exec -- <tool>`. Run `mise exec -- lefthook run pre-commit` before committing.
+- LF line endings; always end files with a trailing newline.
+- Don't hand-edit generated files (`CHANGELOG.md`, release-please manifests,
+  lockfiles) — regenerate them via their owning tool.

--- a/INDEX.md
+++ b/INDEX.md
@@ -29,6 +29,12 @@
 
 - **[Technical Documentation Writer](/.apm/prompts/writing-technical-documentation.prompt.md)** - Generate clear, comprehensive technical documentation for code, APIs, or systems.
 
+## 📐 Instructions
+
+> Long-lived behavior rules deployed to each harness's instruction directory
+
+- **[Devsecninja Conventions](/.apm/instructions/devsecninja-conventions.instructions.md)** (`**`) - DevSecNinja org-wide engineering conventions for AI agents: Conventional-Commit PR titles, pre-PR checks, docs, and no force-push.
+
 ## 🤖 GitHub Copilot Prompts
 
 > Prompts optimized for use with GitHub Copilot in this repository

--- a/README.md
+++ b/README.md
@@ -42,6 +42,12 @@ An organized, reusable toolkit of AI primitives to supercharge your AI coding ha
 
 - **[Technical Documentation Writer](/.apm/prompts/writing-technical-documentation.prompt.md)** - Generate clear, comprehensive technical documentation for code, APIs, or systems.
 
+## 📐 Instructions
+
+> Long-lived behavior rules deployed to each harness's instruction directory
+
+- **[Devsecninja Conventions](/.apm/instructions/devsecninja-conventions.instructions.md)** (`**`) - DevSecNinja org-wide engineering conventions for AI agents: Conventional-Commit PR titles, pre-PR checks, docs, and no force-push.
+
 ## 🤖 GitHub Copilot Prompts
 
 > Prompts optimized for use with GitHub Copilot in this repository

--- a/docs/apm.md
+++ b/docs/apm.md
@@ -16,16 +16,19 @@ there in native APM format — there is no second "browsable" tree to keep in
 sync. The human-facing [`INDEX.md`](../INDEX.md) and the README index are
 *generated from* `.apm/`.
 
-Today the toolkit ships **prompt primitives**
+The toolkit ships **prompt primitives**
 ([`*.prompt.md`](https://microsoft.github.io/apm/producer/author-primitives/prompts/))
-under [`.apm/prompts/`](../.apm/prompts/). The structure is built to grow into
-`.apm/instructions/`, `.apm/agents/`, `.apm/hooks/` and `.apm/skills/` — just add
-the folder and author the primitive.
+under [`.apm/prompts/`](../.apm/prompts/) and **instruction primitives**
+([`*.instructions.md`](https://microsoft.github.io/apm/producer/author-primitives/instructions-and-agents/))
+under [`.apm/instructions/`](../.apm/instructions/). The structure is built to
+grow further into `.apm/agents/`, `.apm/hooks/` and `.apm/skills/` — just add the
+folder and author the primitive.
 
 | File / directory | Role |
 |------------------|------|
 | `apm.yml` | The producer manifest — package name, version and what ships. |
 | `.apm/prompts/*.prompt.md` | The prompt primitives (**source of truth**). |
+| `.apm/instructions/*.instructions.md` | The instruction primitives — long-lived behavior rules (**source of truth**). |
 | `scripts/generate-index.sh` | Generates `INDEX.md` + README index **from** `.apm/`. |
 | `INDEX.md` / README index | Generated, human-browsable catalog. |
 

--- a/scripts/generate-index.sh
+++ b/scripts/generate-index.sh
@@ -2,10 +2,11 @@
 
 # Script to generate INDEX.md from the APM primitives in .apm/.
 #
-# .apm/ is the single source of truth. Each .apm/prompts/<category>-<name>.prompt.md
-# carries `title`, `category` and `description` in its YAML frontmatter. This
-# script reads those, groups by category, and writes INDEX.md plus the
-# auto-generated block in README.md.
+# .apm/ is the single source of truth. Prompt primitives
+# (.apm/prompts/<category>-<name>.prompt.md) carry `title`, `category` and
+# `description`; instruction primitives (.apm/instructions/<name>.instructions.md)
+# carry `description` and `applyTo`. This script reads those and writes INDEX.md
+# plus the auto-generated block in README.md.
 
 set -euo pipefail
 shopt -s nullglob
@@ -59,6 +60,21 @@ while IFS= read -r category; do
   done
   echo "" >> INDEX.md
 done <<< "$categories"
+
+# Process APM instruction primitives (shipped in the package).
+if compgen -G ".apm/instructions/*.instructions.md" > /dev/null; then
+  echo "## 📐 Instructions" >> INDEX.md
+  echo "" >> INDEX.md
+  echo "> Long-lived behavior rules deployed to each harness's instruction directory" >> INDEX.md
+  echo "" >> INDEX.md
+  for f in .apm/instructions/*.instructions.md; do
+    title=$(basename "$f" .instructions.md); title=$(titlecase "$title")
+    description=$(get_field "$f" description)
+    applyTo=$(get_field "$f" applyTo)
+    echo "- **[${title}](/${f})** (\`${applyTo}\`) - ${description}" >> INDEX.md
+  done
+  echo "" >> INDEX.md
+fi
 
 # Process .github/prompts directory (repo-local Copilot prompts, not part of the package).
 if [ -d ".github/prompts" ]; then

--- a/tests/validate-prompts.sh
+++ b/tests/validate-prompts.sh
@@ -61,6 +61,30 @@ for file in .github/prompts/**/*.md; do
   echo ""
 done
 
+# APM instruction primitives: require description + applyTo + a non-empty body.
+for file in .apm/instructions/**/*.instructions.md; do
+  [ -f "$file" ] || continue
+  echo "Checking $file..."
+  FILE_VALID=1
+
+  if ! has_frontmatter "$file"; then
+    echo "❌ Missing YAML frontmatter in $file"; EXIT_CODE=1; FILE_VALID=0
+  else
+    if ! grep -q "^description:" "$file"; then
+      echo "❌ Missing 'description' field in frontmatter in $file"; EXIT_CODE=1; FILE_VALID=0
+    fi
+    if ! grep -q "^applyTo:" "$file"; then
+      echo "❌ Missing 'applyTo' field in frontmatter in $file"; EXIT_CODE=1; FILE_VALID=0
+    fi
+    if [ -z "$(body_after_frontmatter "$file" | tr -d '[:space:]')" ]; then
+      echo "❌ Empty instruction body in $file"; EXIT_CODE=1; FILE_VALID=0
+    fi
+  fi
+
+  [ $FILE_VALID -eq 1 ] && echo "✅ $file is valid"
+  echo ""
+done
+
 if [ $EXIT_CODE -eq 0 ]; then
   echo "✅ All primitives are properly structured!"
 else


### PR DESCRIPTION
## What

Ships DevSecNinja's org-wide engineering conventions as a native **APM instruction primitive** — dogfooding ai-toolkit beyond prompts, and replacing the config-sync approach (closed `DevSecNinja/.github#193`).

- New `.apm/instructions/devsecninja-conventions.instructions.md` (`applyTo: "**"`).
- On `apm install DevSecNinja/ai-toolkit --target copilot` it deploys to `.github/instructions/`; on other harnesses APM compiles it to their native rule directory (`.claude/rules/`, `.cursor/rules/`, `.windsurf/rules/`, `.kiro/steering/`) or folds it into `AGENTS.md`/`GEMINI.md`.

## Why APM instead of config-sync

`instructions` is one of APM's native primitive types. config-sync is for static, non-agentic files (editorconfig, linters, renovate). Putting org instructions in APM is the correct mechanism and the dogfooding goal that motivated this repo. Notably, APM compiles the Copilot target to the **exact same path** config-sync would have written (`.github/instructions/…`), so consumers get an identical on-disk result — just delivered by `apm install`.

## Conventions captured

Conventional-Commit **PR titles** (squash-merge aware → title becomes the release commit), run lint/tests before opening a PR, update docs in the same PR, never force-push to `main`, plus the existing YAML/Markdown/shell/Actions/security standards.

## Repo plumbing (keeps the `.apm/` model coherent)

- `tests/validate-prompts.sh` now validates instruction primitives (`description` + `applyTo` + non-empty body).
- `scripts/generate-index.sh` now emits an **Instructions** section; `INDEX.md`/`README.md` regenerated.
- `docs/apm.md` documents instruction primitives.

## Follow-up (separate PR, in `DevSecNinja/.github`)

A central **`apm-sync` reusable workflow** so repos auto-refresh installed primitives and open a PR (the APM-powered equivalent of config-sync's auto-distribution). Building that next.

Validation + index generation pass locally.