### PR TITLE
feat: add commit-and-release skill primitive

### DIFF
--- a/.apm/skills/commit-and-release/SKILL.md
+++ b/.apm/skills/commit-and-release/SKILL.md
@@ -1,0 +1,130 @@
+---
+name: commit-and-release
+description: "Use when asked to commit, write a commit message, stage files, open a pull request, or cut a release in a DevSecNinja repo. Guides Conventional Commit messages, Conventional-Commit PR titles (repos squash-merge), the pre-commit/validate workflow, and the release-please release flow."
+---
+
+# Commit & Release
+
+DevSecNinja repositories use [Conventional Commits](https://www.conventionalcommits.org),
+**squash-merge** PRs, and automated releases via
+[release-please](https://github.com/googleapis/release-please). This skill is the
+step-by-step procedure; the always-on rules live in the org instruction
+(`devsecninja-conventions`).
+
+## Conventional Commit format
+
+```
+<type>(<scope>): <description>
+```
+
+**Types:** `feat` (new feature → MINOR), `fix` (bug fix → PATCH), `docs`,
+`ci`, `chore`, `refactor`, `perf`, `test`.
+
+**Scope** is the component involved (e.g. a service/module/tool name). Multi-area
+changes may omit the scope.
+
+**Breaking changes** (→ MAJOR) are marked either way (or both):
+
+- `!` before the colon: `feat(api)!: drop v1 endpoints`
+- An uppercase `BREAKING CHANGE:` footer in the commit body.
+
+A new required input to a centralized/reusable workflow IS breaking — mark it so
+Renovate does not automerge a change that breaks downstream CI.
+
+## PR titles matter most
+
+Because repos **squash-merge**, the **PR title becomes the single commit on
+`main`** and is what release-please reads to compute the next version and
+changelog entry. So:
+
+- The **PR title MUST be a valid Conventional Commit subject** (`type(scope): description`).
+- Individual commits inside the PR may be informal — optimize them for review.
+- Validate the intended PR title the same way you validate a commit message:
+
+  ```sh
+  mise exec -- cog verify "feat(auth): add device-code login"
+  ```
+
+  Exit code 0 = valid.
+
+## Commit workflow
+
+Follow these steps in order whenever asked to commit/push.
+
+### 1. Inspect what changed
+
+```sh
+git diff --stat HEAD
+git status --short
+```
+
+### 2. Stage explicitly
+
+Prefer explicit paths over `git add .`:
+
+```sh
+git add path/to/changed-file other/changed-file
+```
+
+If the user already staged files, skip this.
+
+### 3. Draft and validate the message
+
+Draft a Conventional Commit subject, then validate before proposing it:
+
+```sh
+mise exec -- cog verify "fix(parser): handle empty frontmatter"
+```
+
+Fix and re-run until it exits 0.
+
+### 4. Confirm the message with the user
+
+Before committing, present the proposed message and ask the user to confirm
+(offer it as a selectable option plus a free-form "let me edit it" path). If they
+edit it, re-run `cog verify` on the new message.
+
+### 5. Run lint/tests before committing
+
+```sh
+mise exec -- lefthook run pre-commit
+```
+
+Plus the repo's own test command, if any. If anything fails, **stop and report**
+— do not commit or open a PR with known-failing checks.
+
+### 6. Commit and push
+
+```sh
+git commit -m "<confirmed-message>"
+git push
+```
+
+The `commit-msg` hook re-runs `cog verify` automatically; both hooks must pass.
+
+## Opening a pull request
+
+- Set the **PR title to a valid Conventional Commit subject** (see above) — this
+  is the release-critical field.
+- Update documentation in the **same PR** as the code it describes.
+- Keep the PR focused on one logical change.
+- Ensure lint/tests pass before marking it ready.
+- Never force-push to `main` or any shared/protected branch.
+
+## Cutting a release (release-please)
+
+Releases are automated — you do **not** tag or run a release CLI by hand.
+
+1. Merge feature/fix PRs to `main` with Conventional-Commit titles.
+2. release-please opens (or updates) a `chore(main): release vX.Y.Z` PR
+   containing the version bump and `CHANGELOG.md`.
+3. Review that PR; when its checks are green, **merge it**. Merging creates the
+   `vX.Y.Z` tag and the GitHub Release.
+
+To force a specific version, add a `Release-As: X.Y.Z` footer to a commit on
+`main`. The version derives from the Conventional-Commit history since the last
+tag — so accurate PR titles are what make releases correct.
+
+> Repos that have not yet migrated to release-please may still cut releases with
+> `cog bump`; prefer release-please where the
+> `.github/workflows/release-please.yml` caller is present.

--- a/.apm/skills/commit-and-release/SKILL.md
+++ b/.apm/skills/commit-and-release/SKILL.md
@@ -70,21 +70,17 @@ If the user already staged files, skip this.
 
 ### 3. Draft and validate the message
 
-Draft a Conventional Commit subject, then validate before proposing it:
+Write a clear, accurate Conventional Commit subject from the diff and validate it:
 
 ```sh
 mise exec -- cog verify "fix(parser): handle empty frontmatter"
 ```
 
-Fix and re-run until it exits 0.
+Fix and re-run until it exits 0. Don't stop to ask the user to confirm the
+wording — just choose a correct, descriptive message. (If the change is genuinely
+ambiguous about intent — e.g. `feat` vs `fix` — ask only that.)
 
-### 4. Confirm the message with the user
-
-Before committing, present the proposed message and ask the user to confirm
-(offer it as a selectable option plus a free-form "let me edit it" path). If they
-edit it, re-run `cog verify` on the new message.
-
-### 5. Run lint/tests before committing
+### 4. Run lint/tests before committing
 
 ```sh
 mise exec -- lefthook run pre-commit
@@ -93,10 +89,10 @@ mise exec -- lefthook run pre-commit
 Plus the repo's own test command, if any. If anything fails, **stop and report**
 — do not commit or open a PR with known-failing checks.
 
-### 6. Commit and push
+### 5. Commit and push
 
 ```sh
-git commit -m "<confirmed-message>"
+git commit -m "<message>"
 git push
 ```
 
@@ -128,3 +124,18 @@ tag — so accurate PR titles are what make releases correct.
 > Repos that have not yet migrated to release-please may still cut releases with
 > `cog bump`; prefer release-please where the
 > `.github/workflows/release-please.yml` caller is present.
+
+## Always finish with a PR summary table
+
+At the **end of the task**, output a Markdown table of every pull request you
+opened or updated in this session, so the user can open and merge them quickly.
+Include the release-please release PR if one is now open. Use real, clickable
+URLs:
+
+| PR | Title | Status | Link |
+|----|-------|--------|------|
+| #123 | `feat(auth): add device-code login` | open | https://github.com/OWNER/REPO/pull/123 |
+| #124 | `chore(main): release 1.4.0` | open (release) | https://github.com/OWNER/REPO/pull/124 |
+
+If no PR was opened (e.g. a direct push), say so explicitly instead of printing
+an empty table.

--- a/INDEX.md
+++ b/INDEX.md
@@ -35,6 +35,12 @@
 
 - **[Devsecninja Conventions](/.apm/instructions/devsecninja-conventions.instructions.md)** (`**`) - DevSecNinja org-wide engineering conventions for AI agents: Conventional-Commit PR titles, pre-PR checks, docs, and no force-push.
 
+## 🧠 Skills
+
+> Model-invoked guides deployed to each harness's skills directory
+
+- **[Commit And Release](/.apm/skills/commit-and-release/SKILL.md)** - Use when asked to commit, write a commit message, stage files, open a pull request, or cut a release in a DevSecNinja repo. Guides Conventional Commit messages, Conventional-Commit PR titles (repos squash-merge), the pre-commit/validate workflow, and the release-please release flow.
+
 ## 🤖 GitHub Copilot Prompts
 
 > Prompts optimized for use with GitHub Copilot in this repository

--- a/README.md
+++ b/README.md
@@ -48,6 +48,12 @@ An organized, reusable toolkit of AI primitives to supercharge your AI coding ha
 
 - **[Devsecninja Conventions](/.apm/instructions/devsecninja-conventions.instructions.md)** (`**`) - DevSecNinja org-wide engineering conventions for AI agents: Conventional-Commit PR titles, pre-PR checks, docs, and no force-push.
 
+## 🧠 Skills
+
+> Model-invoked guides deployed to each harness's skills directory
+
+- **[Commit And Release](/.apm/skills/commit-and-release/SKILL.md)** - Use when asked to commit, write a commit message, stage files, open a pull request, or cut a release in a DevSecNinja repo. Guides Conventional Commit messages, Conventional-Commit PR titles (repos squash-merge), the pre-commit/validate workflow, and the release-please release flow.
+
 ## 🤖 GitHub Copilot Prompts
 
 > Prompts optimized for use with GitHub Copilot in this repository

--- a/docs/apm.md
+++ b/docs/apm.md
@@ -18,17 +18,20 @@ sync. The human-facing [`INDEX.md`](../INDEX.md) and the README index are
 
 The toolkit ships **prompt primitives**
 ([`*.prompt.md`](https://microsoft.github.io/apm/producer/author-primitives/prompts/))
-under [`.apm/prompts/`](../.apm/prompts/) and **instruction primitives**
+under [`.apm/prompts/`](../.apm/prompts/), **instruction primitives**
 ([`*.instructions.md`](https://microsoft.github.io/apm/producer/author-primitives/instructions-and-agents/))
-under [`.apm/instructions/`](../.apm/instructions/). The structure is built to
-grow further into `.apm/agents/`, `.apm/hooks/` and `.apm/skills/` — just add the
-folder and author the primitive.
+under [`.apm/instructions/`](../.apm/instructions/), and **skill primitives**
+([`SKILL.md`](https://microsoft.github.io/apm/producer/author-primitives/skills/))
+under [`.apm/skills/<name>/`](../.apm/skills/). The structure is built to grow
+further into `.apm/agents/` and `.apm/hooks/` — just add the folder and author the
+primitive.
 
 | File / directory | Role |
 |------------------|------|
 | `apm.yml` | The producer manifest — package name, version and what ships. |
 | `.apm/prompts/*.prompt.md` | The prompt primitives (**source of truth**). |
 | `.apm/instructions/*.instructions.md` | The instruction primitives — long-lived behavior rules (**source of truth**). |
+| `.apm/skills/<name>/SKILL.md` | The skill primitives — model-invoked procedures (**source of truth**). |
 | `scripts/generate-index.sh` | Generates `INDEX.md` + README index **from** `.apm/`. |
 | `INDEX.md` / README index | Generated, human-browsable catalog. |
 

--- a/scripts/generate-index.sh
+++ b/scripts/generate-index.sh
@@ -76,6 +76,20 @@ if compgen -G ".apm/instructions/*.instructions.md" > /dev/null; then
   echo "" >> INDEX.md
 fi
 
+# Process APM skill primitives (shipped in the package).
+if compgen -G ".apm/skills/*/SKILL.md" > /dev/null; then
+  echo "## 🧠 Skills" >> INDEX.md
+  echo "" >> INDEX.md
+  echo "> Model-invoked guides deployed to each harness's skills directory" >> INDEX.md
+  echo "" >> INDEX.md
+  for f in .apm/skills/*/SKILL.md; do
+    name=$(basename "$(dirname "$f")"); title=$(titlecase "$name")
+    description=$(get_field "$f" description)
+    echo "- **[${title}](/${f})** - ${description}" >> INDEX.md
+  done
+  echo "" >> INDEX.md
+fi
+
 # Process .github/prompts directory (repo-local Copilot prompts, not part of the package).
 if [ -d ".github/prompts" ]; then
   echo "## 🤖 GitHub Copilot Prompts" >> INDEX.md

--- a/tests/validate-prompts.sh
+++ b/tests/validate-prompts.sh
@@ -85,6 +85,36 @@ for file in .apm/instructions/**/*.instructions.md; do
   echo ""
 done
 
+# APM skill primitives: require name + description + a non-empty body.
+for file in .apm/skills/**/SKILL.md; do
+  [ -f "$file" ] || continue
+  echo "Checking $file..."
+  FILE_VALID=1
+
+  if ! has_frontmatter "$file"; then
+    echo "❌ Missing YAML frontmatter in $file"; EXIT_CODE=1; FILE_VALID=0
+  else
+    if ! grep -q "^name:" "$file"; then
+      echo "❌ Missing 'name' field in frontmatter in $file"; EXIT_CODE=1; FILE_VALID=0
+    fi
+    if ! grep -q "^description:" "$file"; then
+      echo "❌ Missing 'description' field in frontmatter in $file"; EXIT_CODE=1; FILE_VALID=0
+    fi
+    if [ -z "$(body_after_frontmatter "$file" | tr -d '[:space:]')" ]; then
+      echo "❌ Empty skill body in $file"; EXIT_CODE=1; FILE_VALID=0
+    fi
+    # APM requires the frontmatter name to equal the parent directory name.
+    skill_dir=$(basename "$(dirname "$file")")
+    skill_name=$(awk -F': *' 'NR>1 && /^name:/ {gsub(/^["'\'']|["'\'']$/,"",$2); print $2; exit}' "$file")
+    if [ -n "$skill_name" ] && [ "$skill_name" != "$skill_dir" ]; then
+      echo "❌ Skill 'name' ($skill_name) must equal its directory name ($skill_dir) in $file"; EXIT_CODE=1; FILE_VALID=0
+    fi
+  fi
+
+  [ $FILE_VALID -eq 1 ] && echo "✅ $file is valid"
+  echo ""
+done
+
 if [ $EXIT_CODE -eq 0 ]; then
   echo "✅ All primitives are properly structured!"
 else


### PR DESCRIPTION
## What

Ships a portable **`commit-and-release` skill primitive** (`.apm/skills/commit-and-release/SKILL.md`), adapted from the `DevSecNinja/.github` skill and generalized for any repo. This exercises a **third** APM primitive type (skill) and rounds out the governance trio.

## How the three primitives divide labor

- **Instruction** (`devsecninja-conventions`, shipped in #21) = always-on **rules** (`applyTo: "**"`): PR titles must be conventional, run lint, update docs, no force-push.
- **Skill** (this) = a reached-for **procedure**, auto-discovered when the user says "commit this" / "open a PR" / "cut a release": the step-by-step workflow.
- **Prompts** = on-demand templates.

No duplication — APM's primitive taxonomy maps cleanly onto rules vs. procedures.

## Changes from the source skill

- **Explicit PR-title section** (your ask): repos **squash-merge**, so the PR title becomes the `main` commit release-please reads — it MUST be a valid Conventional Commit subject. Called out as the release-critical field.
- **Release section rewritten to release-please** (merge the `chore(main): release` PR) instead of the legacy `cog bump` flow, matching the org standard. `cog bump` kept as a one-line note for unmigrated repos.
- Dropped `.github`-repo-specific examples (homelab services) for portability.
- Kept `cog verify` for commit-message / PR-title validation.

## Deploys to

`apm install … --target copilot` → `.agents/skills/commit-and-release/` (Copilot/Cursor/Codex/Gemini/OpenCode converge there); Claude → `.claude/skills/`, Windsurf/Kiro → their native skill dirs.

## Repo plumbing

- `validate-prompts.sh` validates skills (`name` + `description` + body; enforces APM's rule that `name` equals the directory).
- `generate-index.sh` emits a **Skills** section; `INDEX.md`/`README.md` regenerated.
- `docs/apm.md` documents skill primitives.

Validation + index generation pass locally (pre-commit hook green).