### PR TITLE
feat: declare GitHub and Microsoft Learn MCP servers

### DIFF
--- a/apm.yml
+++ b/apm.yml
@@ -18,7 +18,18 @@ description: A curated, multi-harness toolkit of AI primitives (prompts, instruc
 author: DevSecNinja
 dependencies:
   apm: []
-  mcp: []
+  # MCP servers consumers get wired into their harness on `apm install`.
+  # Declarations only — APM materializes them into each harness's MCP config.
+  mcp:
+    # GitHub MCP server (repos, issues, PRs, Actions, code search). Resolved
+    # from the GitHub MCP registry; APM injects the auth token per harness.
+    - io.github.github/github-mcp-server
+    # Microsoft Learn MCP server — trusted, up-to-date Microsoft/Azure docs and
+    # code samples. Public remote server, no authentication required.
+    - name: microsoft-learn
+      registry: false
+      transport: http
+      url: https://learn.microsoft.com/api/mcp
 # "auto" walks the local .apm/ tree and deploys every primitive it finds.
 includes: auto
 scripts: {}

--- a/docs/apm.md
+++ b/docs/apm.md
@@ -26,11 +26,22 @@ folder and author the primitive.
 
 | File / directory | Role |
 |------------------|------|
-| `apm.yml` | The producer manifest — package name, version and what ships. |
+| `apm.yml` | The producer manifest — package name, version, MCP servers, and what ships. |
 | `.apm/prompts/*.prompt.md` | The prompt primitives (**source of truth**). |
 | `.apm/instructions/*.instructions.md` | The instruction primitives — long-lived behavior rules (**source of truth**). |
 | `scripts/generate-index.sh` | Generates `INDEX.md` + README index **from** `.apm/`. |
 | `INDEX.md` / README index | Generated, human-browsable catalog. |
+
+### MCP servers
+
+The toolkit also declares **MCP servers** under `dependencies.mcp:` in `apm.yml`.
+Unlike file-based primitives these are declarations, not files — `apm install`
+materializes them into each detected harness's MCP config:
+
+| Server | Type | Notes |
+|--------|------|-------|
+| `io.github.github/github-mcp-server` | registry | GitHub repos/issues/PRs/Actions; APM injects the auth token per harness. |
+| `microsoft-learn` | remote (`http`) | Trusted Microsoft/Azure docs + code samples at `https://learn.microsoft.com/api/mcp`; no auth. |
 
 ### Primitive frontmatter
 


### PR DESCRIPTION
## What

Declares two **MCP servers** in `apm.yml` so consumers get them wired into their harness automatically on `apm install` — extending the toolkit to a fourth APM primitive type (MCP).

```yaml
dependencies:
  mcp:
    - io.github.github/github-mcp-server
    - name: microsoft-learn
      registry: false
      transport: http
      url: https://learn.microsoft.com/api/mcp
```

- **GitHub MCP server** — registry reference (`io.github.github/github-mcp-server`); repos, issues, PRs, Actions, code search. APM injects the auth token per harness automatically (it's a special-cased server).
- **Microsoft Learn MCP server** — self-defined public remote (streamable HTTP at `https://learn.microsoft.com/api/mcp`, **no auth**); trusted, up-to-date Microsoft/Azure docs + code samples. Confirmed transport/endpoint from the [official MS Learn MCP overview](https://learn.microsoft.com/en-us/training/support/mcp).

## Notes

- MCP servers are **declarations**, not files under `.apm/` — APM materializes them into each detected harness's MCP config (`.vscode/mcp.json`, `.cursor/mcp.json`, etc.). So they don't appear in the generated `INDEX.md`.
- No secrets committed (MS Learn needs none; GitHub token is injected by APM/the harness at runtime).
- Documented in `docs/apm.md` (new MCP servers table).
- `apm.yml` parses and validates against the documented schema; `validate-prompts.sh` still passes.