### PR TITLE
chore: materialize APM primitives from apm.yml

### DIFF
--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -1,5 +1,5 @@
 lockfile_version: '1'
-generated_at: '2026-06-23T09:10:18.237397+00:00'
+generated_at: '2026-06-23T11:56:50.727466+00:00'
 apm_version: 0.21.0
 dependencies:
 - repo_url: github/awesome-copilot
@@ -8,156 +8,143 @@ dependencies:
   resolved_ref: 3e36d367091a1e67b77974cade6f1aa48bc77a81
   virtual_path: agents/accessibility.agent.md
   is_virtual: true
-  package_type: apm_package
   deployed_files:
   - .github/agents/accessibility.agent.md
   deployed_file_hashes:
-    .github/agents/accessibility.agent.md: sha256:fe79c1ffb138fae09155c852a78ab92a841279aa117d1c60d6035d4f707b351a
-  content_hash: sha256:31460dfae4bcbb080e9298bd56049c6f82608f9a43af39d740d0bca2e02ed4e1
+    .github/agents/accessibility.agent.md: sha256:739ed64a0ef2e7f560ef16329e7f6d7fedfdfbcc3f00382a926d33f978e614d0
+  content_hash: sha256:a3c3e1f2028a217ec937ee436a9756295899b67ffc750b9acfa9b91ac9ff9bf9
 - repo_url: github/awesome-copilot
   host: github.com
   resolved_commit: 3e36d367091a1e67b77974cade6f1aa48bc77a81
   resolved_ref: 3e36d367091a1e67b77974cade6f1aa48bc77a81
   virtual_path: agents/adr-generator.agent.md
   is_virtual: true
-  package_type: apm_package
   deployed_files:
   - .github/agents/adr-generator.agent.md
   deployed_file_hashes:
-    .github/agents/adr-generator.agent.md: sha256:cccff71d07da590a865e29de5a00f59ab106f89d59e90d986efcf711065c85ba
-  content_hash: sha256:eb8dc2e6ac265105ae09197b485cdd2cc0e579f09c6b72e1f657b20b987710e8
+    .github/agents/adr-generator.agent.md: sha256:abbf07c6a768a21baa94a1aed858510c8038cb89866461d47ab64817e9f347ac
+  content_hash: sha256:870b03e1c10d26b2fd03b7369872ee7493abfca5f508d15406ad09116c39c52d
 - repo_url: github/awesome-copilot
   host: github.com
   resolved_commit: 3e36d367091a1e67b77974cade6f1aa48bc77a81
   resolved_ref: 3e36d367091a1e67b77974cade6f1aa48bc77a81
   virtual_path: agents/devops-expert.agent.md
   is_virtual: true
-  package_type: apm_package
   deployed_files:
   - .github/agents/devops-expert.agent.md
   deployed_file_hashes:
-    .github/agents/devops-expert.agent.md: sha256:e7db97e279c7539cc0af8c4b0cf92d18d4227da29b5acc63405aa62a23fceed5
-  content_hash: sha256:ec5901e421fe3041f8c50ac7c6ebe6bf52b6dde6037a47d48ae26be4c8ffb198
+    .github/agents/devops-expert.agent.md: sha256:63197c5250702760e79fb3ccb4e2b154b1a52b41ac62e7d45ae2def6eea23952
+  content_hash: sha256:fa7a318e88b5a91f72a4c6cda23f1cc863becdc0c14b141fd99dddc4d475c5fa
 - repo_url: github/awesome-copilot
   host: github.com
   resolved_commit: 3e36d367091a1e67b77974cade6f1aa48bc77a81
   resolved_ref: 3e36d367091a1e67b77974cade6f1aa48bc77a81
   virtual_path: agents/github-actions-expert.agent.md
   is_virtual: true
-  package_type: apm_package
   deployed_files:
   - .github/agents/github-actions-expert.agent.md
   deployed_file_hashes:
-    .github/agents/github-actions-expert.agent.md: sha256:034ca7a8efd5118caa3ff3221b71e3e94dbd171919651152c50c553fa3a9d392
-  content_hash: sha256:6ebd8f3b7c87667280a5a819f1d78938e73e7602159dc8ccd77fe406e318fbd7
+    .github/agents/github-actions-expert.agent.md: sha256:9a113142559959683041c85c094ca32541fa7e0db42d3510acf6d79a68bbb597
+  content_hash: sha256:e4e9fe25710ba27716b2c5b588835b744fb7806cbbd795f3e9bc657f5b30a02f
 - repo_url: github/awesome-copilot
   host: github.com
   resolved_commit: 3e36d367091a1e67b77974cade6f1aa48bc77a81
   resolved_ref: 3e36d367091a1e67b77974cade6f1aa48bc77a81
   virtual_path: agents/linkedin-post-writer.agent.md
   is_virtual: true
-  package_type: apm_package
   deployed_files:
   - .github/agents/linkedin-post-writer.agent.md
   deployed_file_hashes:
-    .github/agents/linkedin-post-writer.agent.md: sha256:d51232621776ff13fb2c452d1073a8720ec38b30de57876d0ad6d5c7f4a9d628
-  content_hash: sha256:857936a473e5cb9bd815fb189dc06e1f2e2ea4c4de99c33a62037a89e3e194c5
+    .github/agents/linkedin-post-writer.agent.md: sha256:1a6c8505fb43e6636af78914728c87283d5908a8a25dc4d8fef8cf96c0d24b9a
+  content_hash: sha256:e9a43addf0e5b71fa803df46929d86d95fbe46a68bc9d3456b134e0973691d08
 - repo_url: github/awesome-copilot
   host: github.com
   resolved_commit: 3e36d367091a1e67b77974cade6f1aa48bc77a81
   resolved_ref: 3e36d367091a1e67b77974cade6f1aa48bc77a81
   virtual_path: agents/project-architecture-planner.agent.md
   is_virtual: true
-  package_type: apm_package
   deployed_files:
   - .github/agents/project-architecture-planner.agent.md
   deployed_file_hashes:
-    .github/agents/project-architecture-planner.agent.md: sha256:8fca6222812d23bfa9e1619ed8d6711d75a2b188734807e8ffc566252ab5c861
-  content_hash: sha256:fd3c7187c8be106fb49e3129162a9f81c096e5202dd158a47df3b20693213a5d
+    .github/agents/project-architecture-planner.agent.md: sha256:11ce5dc54676fbe183849a4c0d317e5d893d012e6fc32a99b1ac22f9a173ad6c
+  content_hash: sha256:c69e622fc28420487155bc417fa2627692de63f42cbd0abb40ef4ade11d6a4ac
 - repo_url: github/awesome-copilot
   host: github.com
   resolved_commit: 3e36d367091a1e67b77974cade6f1aa48bc77a81
   resolved_ref: 3e36d367091a1e67b77974cade6f1aa48bc77a81
   virtual_path: agents/prompt-builder.agent.md
   is_virtual: true
-  package_type: apm_package
   deployed_files:
   - .github/agents/prompt-builder.agent.md
   deployed_file_hashes:
-    .github/agents/prompt-builder.agent.md: sha256:0e8fdbcc477c36ce1e2a8d06b66698958f3f2f6a6370fc33704df000c762f9f5
-  content_hash: sha256:a7a9bee21922e5a643751523ea47a53ae7ef685c0a1fc620d655cc87574d5923
+    .github/agents/prompt-builder.agent.md: sha256:1f2296311ebdb3c082bab8194a377adf6207e88522227cc381158402549b0f1a
+  content_hash: sha256:4a795556672aa5ce01c5d178879249ebb75304e4641c6a2e072d854a8d645f24
 - repo_url: github/awesome-copilot
   host: github.com
   resolved_commit: 3e36d367091a1e67b77974cade6f1aa48bc77a81
   resolved_ref: 3e36d367091a1e67b77974cade6f1aa48bc77a81
   virtual_path: agents/sast-sca-security-analyzer.agent.md
   is_virtual: true
-  package_type: apm_package
   deployed_files:
   - .github/agents/sast-sca-security-analyzer.agent.md
   deployed_file_hashes:
-    .github/agents/sast-sca-security-analyzer.agent.md: sha256:75ba76fcc3ec735ed3edf6312da055ca58b215d35df5c3be08314d35bf5e7b7c
-  content_hash: sha256:c493a2705524541e7beb53e2467d8594cec0a37c4a0b969e0e1def892bb08642
+    .github/agents/sast-sca-security-analyzer.agent.md: sha256:5980dc5817b48eea6f88d25f847fcac11b3131f5f9444856bfda243d2c808518
+  content_hash: sha256:50fdb7762c88ce0d470ad9d9158a1769abb060cfb62c7377f446428577e72198
 - repo_url: github/awesome-copilot
   host: github.com
   resolved_commit: 3e36d367091a1e67b77974cade6f1aa48bc77a81
   resolved_ref: 3e36d367091a1e67b77974cade6f1aa48bc77a81
   virtual_path: agents/se-security-reviewer.agent.md
   is_virtual: true
-  package_type: apm_package
   deployed_files:
   - .github/agents/se-security-reviewer.agent.md
   deployed_file_hashes:
-    .github/agents/se-security-reviewer.agent.md: sha256:98065e5c9a8079dd902fd3454467674c97d27f8818824aad0a12db6b7d5c8516
-  content_hash: sha256:2a3c29cfb763424d217fb6fcfefeb93a32691754202ba613705073fa2ad67925
+    .github/agents/se-security-reviewer.agent.md: sha256:3b5fec1f93bf21e20b865493ceca30708738642887d00c68e0bd0051f2d0e1fc
+  content_hash: sha256:33fa3b7dc11421521bcec467e8b08289d6f24dd27ca0b48ec70246f0215d6028
 - repo_url: github/awesome-copilot
   host: github.com
   resolved_commit: 3e36d367091a1e67b77974cade6f1aa48bc77a81
   resolved_ref: 3e36d367091a1e67b77974cade6f1aa48bc77a81
   virtual_path: agents/se-technical-writer.agent.md
   is_virtual: true
-  package_type: apm_package
   deployed_files:
   - .github/agents/se-technical-writer.agent.md
   deployed_file_hashes:
-    .github/agents/se-technical-writer.agent.md: sha256:bd414b4af2bb7423f59361fc03c22b9d63347d448a2e5f52ffece68d6168ae1b
-  content_hash: sha256:e209327bd2509b726a799ec06a398c32aa2ea6ea166a1b9eb8ac4760ac182ef6
+    .github/agents/se-technical-writer.agent.md: sha256:e2b7fe3959fee4701084022bdfb6bae9c24b2890d44305f17d779d0055ec9506
+  content_hash: sha256:01ea91d50b704e0584f923204cb4384732298a258c139b6cc9f2dce6e46480f2
 - repo_url: github/awesome-copilot
   host: github.com
   resolved_commit: 3e36d367091a1e67b77974cade6f1aa48bc77a81
   resolved_ref: 3e36d367091a1e67b77974cade6f1aa48bc77a81
   virtual_path: agents/se-ux-ui-designer.agent.md
   is_virtual: true
-  package_type: apm_package
   deployed_files:
   - .github/agents/se-ux-ui-designer.agent.md
   deployed_file_hashes:
-    .github/agents/se-ux-ui-designer.agent.md: sha256:8bd92d41f54d2e09a9e3f1e0ea08944b03a9e5d74eb3a7de805eaf8ebf63ce0f
-  content_hash: sha256:39d62eb52cda3eec692a8d943a31f29ce1175b355154a52efad59d31779c845e
+    .github/agents/se-ux-ui-designer.agent.md: sha256:a7078735984cfec19643027b8e876435b3d73f43ab431f910186e16a11b0bdd2
+  content_hash: sha256:3ece1e14070990d48a65700c10c31fc3b37fd1cdbbfe8fbde7e8adc227bbe5fd
 - repo_url: github/awesome-copilot
   host: github.com
   resolved_commit: 3e36d367091a1e67b77974cade6f1aa48bc77a81
   resolved_ref: 3e36d367091a1e67b77974cade6f1aa48bc77a81
   virtual_path: agents/software-engineer-agent-v1.agent.md
   is_virtual: true
-  package_type: apm_package
   deployed_files:
   - .github/agents/software-engineer-agent-v1.agent.md
   deployed_file_hashes:
-    .github/agents/software-engineer-agent-v1.agent.md: sha256:129552bb554b6b1f2124b5dc09eea936b50e27e26de2c0a11edc965714268f8a
-  content_hash: sha256:24700fb01bafb55cb1f2cb22e38a3b1cd37780bbb6faff14a0b848961e98e6d7
+    .github/agents/software-engineer-agent-v1.agent.md: sha256:79ebbe7c389bc6043ac0a0e0f48ba8431d7f573deed3fd049c42f4cc27930f0b
+  content_hash: sha256:2a11ebcc3a3c2ad023f2159a691b35cca83b4abc7125b7478619ab4561b29101
 - repo_url: github/awesome-copilot
   host: github.com
   resolved_commit: 3e36d367091a1e67b77974cade6f1aa48bc77a81
   resolved_ref: 3e36d367091a1e67b77974cade6f1aa48bc77a81
   virtual_path: agents/task-planner.agent.md
   is_virtual: true
-  package_type: apm_package
   deployed_files:
   - .github/agents/task-planner.agent.md
   deployed_file_hashes:
-    .github/agents/task-planner.agent.md: sha256:6fb553d785a9e26e7cae034527acf3d363c8ac2acb6dc11dd8235a6fcca0f975
-  content_hash: sha256:66a7af3bad399166291c0a927492b3f744a5d6db137699801bd537f04dec6c6c
+    .github/agents/task-planner.agent.md: sha256:396e333df4318d590a8b07f960a61361169689d68896731149ea1f5a11ddc8fd
+  content_hash: sha256:868b1c2b411f4857a13f5fe32279589a836ed6d7c4b257d5ba1d5af0d1546c6a
 local_deployed_files:
 - .agents/skills/commit-and-release
 - .agents/skills/commit-and-release/SKILL.md
@@ -195,11 +182,11 @@ local_deployed_file_hashes:
   .agents/skills/meeting-transcript-creation/SKILL.md: sha256:9287214edd7a5703b85b3b18fea54b7ad00cc49bde09c1ae3a75a3f0364eb130
   .agents/skills/morning-briefing/SKILL.md: sha256:d5496aa416534df0be1f301d03a3d74dfb3f84cd72aafb33573a59c0c4af525b
   .agents/skills/ooo-task-handoff-planner/SKILL.md: sha256:8886cdf1b9effe8a877e890d09fa54281ab680516a3837f0b24b0110d7c4d8b9
-  .github/agents/dutch-housing-advisor.agent.md: sha256:258095e7d019f13b62578ea67bf3a363b6c9dd200218dabf6222f57dd63ba256
-  .github/agents/personal-assistant.agent.md: sha256:07bd3008773513b5f5478933513b6f224b232d98212a789df2a0100281c865fd
-  .github/hooks/ai-toolkit-tool-guardian.json: sha256:37fa76a417af448c127fd9da65b9996b8f06e92c727c309594194b3ecaa98b46
+  .github/agents/dutch-housing-advisor.agent.md: sha256:89c5e2b6fe6d20d9c8ba7db59dc91318adeebe1d80f0b97c8e6f2e4065d4d8f7
+  .github/agents/personal-assistant.agent.md: sha256:a48a53144bfc4bc62d2a20f2a984f1fb55ad9ec98d30dfeccff0276e86740b65
+  .github/hooks/ai-toolkit-tool-guardian.json: sha256:175c84353fd9f0de733cb9badb52e26a65adbf62c5ef532e82224bb7d1043c84
   .github/hooks/scripts/ai-toolkit/scripts/tool-guardian/guard-tool.sh: sha256:f74d1860c92308da65d39576e3cf36413942084f51345fd29e63b55bf0ae5d18
-  .github/instructions/devsecninja-conventions.instructions.md: sha256:cae5797e9754190863c7eaaae73dcdb6e8bf4b0ce8ad5897c6db5aec60568e8a
-  .github/prompts/coding-copilot-onboarding.prompt.md: sha256:7dba4b8abe245cfdfae299f8643adbca6760d33300cff248c1778f863463a6d3
-  .github/prompts/home-assistant-automation-renamer.prompt.md: sha256:dce2d61ce6aa32062f4a4547a157abcba0ee96cad1f3a90ca13a5c80f908eff9
-  .github/prompts/home-assistant-notification-optimizer.prompt.md: sha256:3109ed96a5a17fa8c8d7e7a47f35174e3769bfc0e1fac2a6fd8e008dcb52beca
+  .github/instructions/devsecninja-conventions.instructions.md: sha256:70f5a0e9782f00bcce24a453f37eb1e239584360e3f0f2dfe9cf2e5721d2be3e
+  .github/prompts/coding-copilot-onboarding.prompt.md: sha256:68b159cdc1d1b151bb1f6c507de6bd6c2ef51d3d119b851aba69bf250252eacf
+  .github/prompts/home-assistant-automation-renamer.prompt.md: sha256:fe65b8df8184dd21fe84e6d9b9873fa2ef407553d5f7bbe8c9ad50fb3b3bc2b2
+  .github/prompts/home-assistant-notification-optimizer.prompt.md: sha256:bef7b8a47605fd61dcdd6eb1e60b8294e9f25f5bf2a60662e1cfa7a8c7e2b64a


### PR DESCRIPTION
## Description

<!-- Briefly describe what this PR does. -->

## Changes

<!-- List the key changes. -->
This pull request updates the `apm.lock.yaml` file, primarily to refresh deployed agent file hashes and content hashes, and to remove the redundant `package_type` field from agent entries. These changes ensure that the lockfile accurately reflects the current state of deployed files and their integrity, likely after upstream changes or redeployments.

Key changes include:

**Agent Metadata and Integrity Updates**
* Removed the `package_type: apm_package` field from all agent entries, simplifying metadata for each agent in the dependencies list.
* Updated the `deployed_file_hashes` and `content_hash` values for all agents to reflect new file versions, ensuring integrity checks use current file contents.

**Local Deployed File Hash Updates**
* Updated hash values for several locally deployed files, including agent definitions and hooks, to match their latest versions.

**Lockfile Metadata**
* Updated the `generated_at` timestamp to reflect the most recent lockfile generation.

-

## Checklist

- [ ] Linting passes locally (`mise exec -- lefthook run pre-commit`)
- [ ] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org)
- [ ] Documentation updated (if applicable)
