### PR TITLE
feat(skills): add obsidian skill (markdown + bases) with MIT attribution

### DIFF
--- a/.apm/skills/obsidian/LICENSE
+++ b/.apm/skills/obsidian/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Steph Ango (@kepano)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/.apm/skills/obsidian/SKILL.md
+++ b/.apm/skills/obsidian/SKILL.md
@@ -1,0 +1,237 @@
+---
+name: obsidian
+description: Create and edit Obsidian content -- Obsidian Flavored Markdown (wikilinks, embeds, callouts, properties, tags) and Bases (.base database views with filters, formulas, and summaries). Use when working with Obsidian notes or .base files, or when the user mentions wikilinks, callouts, frontmatter, tags, embeds, Bases, table/card views, filters, or formulas in Obsidian.
+targets:
+  - copilot
+  - claude
+  - agent-skills
+---
+
+# Obsidian Flavored Markdown Skill
+
+Create and edit valid Obsidian Flavored Markdown. Obsidian extends CommonMark
+and GFM with wikilinks, embeds, callouts, properties, comments, and other syntax.
+This skill covers only Obsidian-specific extensions -- standard Markdown
+(headings, bold, italic, lists, quotes, code blocks, tables) is assumed knowledge.
+
+## Workflow: Creating an Obsidian Note
+
+1. **Add frontmatter** with properties (title, tags, aliases) at the top of the
+   file. See [PROPERTIES.md](references/PROPERTIES.md) for all property types.
+2. **Write content** using standard Markdown for structure, plus
+   Obsidian-specific syntax below.
+3. **Link related notes** using wikilinks (`[[Note]]`) for internal vault
+   connections, or standard Markdown links for external URLs.
+4. **Embed content** from other notes, images, or PDFs using the `![[embed]]`
+   syntax. See [EMBEDS.md](references/EMBEDS.md) for all embed types.
+5. **Add callouts** for highlighted information using `> [!type]` syntax. See
+   [CALLOUTS.md](references/CALLOUTS.md) for all callout types.
+6. **Verify** the note renders correctly in Obsidian's reading view.
+
+> When choosing between wikilinks and Markdown links: use `[[wikilinks]]` for
+> notes within the vault (Obsidian tracks renames automatically) and `[text](url)`
+> for external URLs only.
+
+## Internal Links (Wikilinks)
+
+```markdown
+[[Note Name]]                          Link to note
+[[Note Name|Display Text]]             Custom display text
+[[Note Name#Heading]]                  Link to heading
+[[Note Name#^block-id]]                Link to block
+[[#Heading in same note]]              Same-note heading link
+```
+
+Define a block ID by appending `^block-id` to any paragraph:
+
+```markdown
+This paragraph can be linked to. ^my-block-id
+```
+
+For lists and quotes, place the block ID on a separate line after the block:
+
+```markdown
+> A quote block
+
+^quote-id
+```
+
+## Embeds
+
+Prefix any wikilink with `!` to embed its content inline:
+
+```markdown
+![[Note Name]]                         Embed full note
+![[Note Name#Heading]]                 Embed section
+![[image.png]]                         Embed image
+![[image.png|300]]                     Embed image with width
+![[document.pdf#page=3]]               Embed PDF page
+```
+
+See [EMBEDS.md](references/EMBEDS.md) for audio, video, search embeds, and
+external images.
+
+## Callouts
+
+```markdown
+> [!note]
+> Basic callout.
+
+> [!warning] Custom Title
+> Callout with a custom title.
+
+> [!faq]- Collapsed by default
+> Foldable callout (- collapsed, + expanded).
+```
+
+Common types: `note`, `tip`, `warning`, `info`, `example`, `quote`, `bug`,
+`danger`, `success`, `failure`, `question`, `abstract`, `todo`.
+
+See [CALLOUTS.md](references/CALLOUTS.md) for the full list with aliases,
+nesting, and custom CSS callouts.
+
+## Properties (Frontmatter)
+
+```yaml
+---
+title: My Note
+date: 2024-01-15
+tags:
+  - project
+  - active
+aliases:
+  - Alternative Name
+cssclasses:
+  - custom-class
+---
+```
+
+Default properties: `tags` (searchable labels), `aliases` (alternative note names
+for link suggestions), `cssclasses` (CSS classes for styling).
+
+See [PROPERTIES.md](references/PROPERTIES.md) for all property types, tag syntax
+rules, and advanced usage.
+
+## Tags
+
+```markdown
+#tag                    Inline tag
+#nested/tag             Nested tag with hierarchy
+```
+
+Tags can contain letters, numbers (not first character), underscores, hyphens,
+and forward slashes. Tags can also be defined in frontmatter under the `tags`
+property.
+
+## Comments
+
+```markdown
+This is visible %%but this is hidden%% text.
+
+%%
+This entire block is hidden in reading view.
+%%
+```
+
+## Obsidian-Specific Formatting
+
+```markdown
+==Highlighted text==                   Highlight syntax
+```
+
+## Math (LaTeX)
+
+```markdown
+Inline: $e^{i\pi} + 1 = 0$
+
+Block:
+$$
+\frac{a}{b} = c
+$$
+```
+
+## Diagrams (Mermaid)
+
+````markdown
+```mermaid
+graph TD
+    A[Start] --> B{Decision}
+    B -->|Yes| C[Do this]
+    B -->|No| D[Do that]
+```
+````
+
+To link Mermaid nodes to Obsidian notes, add `class NodeName internal-link;`.
+
+## Footnotes
+
+```markdown
+Text with a footnote[^1].
+
+[^1]: Footnote content.
+
+Inline footnote.^[This is inline.]
+```
+
+## Complete Example
+
+````markdown
+---
+title: Project Alpha
+date: 2024-01-15
+tags:
+  - project
+  - active
+status: in-progress
+---
+
+# Project Alpha
+
+This project aims to [[improve workflow]] using modern techniques.
+
+> [!important] Key Deadline
+> The first milestone is due on ==January 30th==.
+
+## Tasks
+
+- [x] Initial planning
+- [ ] Development phase
+  - [ ] Backend implementation
+  - [ ] Frontend design
+
+## Notes
+
+The algorithm uses $O(n \log n)$ sorting. See [[Algorithm Notes#Sorting]] for details.
+
+![[Architecture Diagram.png|600]]
+
+Reviewed in [[Meeting Notes 2024-01-10#Decisions]].
+````
+
+## Bases (database views)
+
+Obsidian Bases are `.base` files (YAML) that render database-like views (table,
+cards, list, map) over your notes, with filters, formulas, and summaries. When
+creating or editing `.base` files, follow the full syntax, quoting rules, and
+function reference in [BASES.md](references/BASES.md) and
+[FUNCTIONS_REFERENCE.md](references/FUNCTIONS_REFERENCE.md).
+
+Embed a base in a note with `![[MyBase.base]]` (or `![[MyBase.base#View Name]]`
+for a specific view).
+
+## References
+
+- [Obsidian Flavored Markdown](https://help.obsidian.md/obsidian-flavored-markdown)
+- [Internal links](https://help.obsidian.md/links)
+- [Embed files](https://help.obsidian.md/embeds)
+- [Callouts](https://help.obsidian.md/callouts)
+- [Properties](https://help.obsidian.md/properties)
+- [Bases syntax](https://help.obsidian.md/bases/syntax)
+
+## Credits & License
+
+This skill is adapted from the `obsidian-markdown` and `obsidian-bases` skills in
+[kepano/obsidian-skills](https://github.com/kepano/obsidian-skills),
+© 2026 Steph Ango (@kepano), licensed under the MIT License. The original MIT
+copyright and permission notice is bundled alongside this skill in
+[`LICENSE`](LICENSE).

--- a/.apm/skills/obsidian/references/BASES.md
+++ b/.apm/skills/obsidian/references/BASES.md
@@ -1,0 +1,497 @@
+# Obsidian Bases (.base files)
+
+Create and edit Obsidian Bases: `.base` files that define database-like views
+(table, cards, list, map) over notes, with filters, formulas, and summaries.
+
+## Workflow
+
+1. **Create the file**: Create a `.base` file in the vault with valid YAML content
+2. **Define scope**: Add `filters` to select which notes appear (by tag, folder, property, or date)
+3. **Add formulas** (optional): Define computed properties in the `formulas` section
+4. **Configure views**: Add one or more views (`table`, `cards`, `list`, or `map`) with `order` specifying which properties to display
+5. **Validate**: Verify the file is valid YAML with no syntax errors. Check that all referenced properties and formulas exist. Common issues: unquoted strings containing special YAML characters, mismatched quotes in formula expressions, referencing `formula.X` without defining `X` in `formulas`
+6. **Test in Obsidian**: Open the `.base` file in Obsidian to confirm the view renders correctly. If it shows a YAML error, check quoting rules below
+
+## Schema
+
+Base files use the `.base` extension and contain valid YAML.
+
+```yaml
+# Global filters apply to ALL views in the base
+filters:
+  # Can be a single filter string
+  # OR a recursive filter object with exactly ONE key: and, or, or not
+  and:
+    - 'status == "active"'
+    - not:
+        - 'file.hasTag("archived")'
+
+# Define formula properties that can be used across all views
+formulas:
+  formula_name: 'expression'
+
+# Configure display names and settings for properties
+properties:
+  property_name:
+    displayName: "Display Name"
+  formula.formula_name:
+    displayName: "Formula Display Name"
+  file.ext:
+    displayName: "Extension"
+
+# Define custom summary formulas
+summaries:
+  custom_summary_name: 'values.mean().round(3)'
+
+# Define one or more views
+views:
+  - type: table | cards | list | map
+    name: "View Name"
+    limit: 10                    # Optional: limit results
+    groupBy:                     # Optional: group results
+      property: property_name
+      direction: ASC | DESC
+    filters:                     # View-specific filters follow the same rules
+      and:
+        - 'status == "active"'
+    order:                       # Properties to display in order
+      - file.name
+      - property_name
+      - formula.formula_name
+    summaries:                   # Map properties to summary formulas
+      property_name: Average
+```
+
+## Filter Syntax
+
+Filters narrow down results. They can be applied globally or per-view.
+
+### Filter Structure
+
+```yaml
+# Single filter
+filters: 'status == "done"'
+
+# AND - all conditions must be true
+filters:
+  and:
+    - 'status == "done"'
+    - 'priority > 3'
+
+# OR - any condition can be true
+filters:
+  or:
+    - 'file.hasTag("book")'
+    - 'file.hasTag("article")'
+
+# NOT - exclude matching items
+filters:
+  not:
+    - 'file.hasTag("archived")'
+
+# Nested filters
+filters:
+  or:
+    - file.hasTag("tag")
+    - and:
+        - file.hasTag("book")
+        - file.hasLink("Textbook")
+    - not:
+        - file.hasTag("book")
+        - file.inFolder("Required Reading")
+```
+
+### Filter Operators
+
+| Operator | Description |
+|----------|-------------|
+| `==` | equals |
+| `!=` | not equal |
+| `>` | greater than |
+| `<` | less than |
+| `>=` | greater than or equal |
+| `<=` | less than or equal |
+| `&&` | logical and |
+| `\|\|` | logical or |
+| <code>!</code> | logical not |
+
+## Properties
+
+### Three Types of Properties
+
+1. **Note properties** - From frontmatter: `note.author` or just `author`
+2. **File properties** - File metadata: `file.name`, `file.mtime`, etc.
+3. **Formula properties** - Computed values: `formula.my_formula`
+
+### File Properties Reference
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `file.name` | String | File name |
+| `file.basename` | String | File name without extension |
+| `file.path` | String | Full path to file |
+| `file.folder` | String | Parent folder path |
+| `file.ext` | String | File extension |
+| `file.size` | Number | File size in bytes |
+| `file.ctime` | Date | Created time |
+| `file.mtime` | Date | Modified time |
+| `file.tags` | List | All tags in file |
+| `file.links` | List | Internal links in file |
+| `file.backlinks` | List | Files linking to this file |
+| `file.embeds` | List | Embeds in the note |
+| `file.properties` | Object | All frontmatter properties |
+
+### The `this` Keyword
+
+- In main content area: refers to the base file itself
+- When embedded: refers to the embedding file
+- In sidebar: refers to the active file in main content
+
+## Formula Syntax
+
+Formulas compute values from properties. Defined in the `formulas` section.
+
+```yaml
+formulas:
+  # Simple arithmetic
+  total: "price * quantity"
+
+  # Conditional logic
+  status_icon: 'if(done, "✅", "⏳")'
+
+  # String formatting
+  formatted_price: 'if(price, price.toFixed(2) + " dollars")'
+
+  # Date formatting
+  created: 'file.ctime.format("YYYY-MM-DD")'
+
+  # Calculate days since created (use .days for Duration)
+  days_old: '(now() - file.ctime).days'
+
+  # Calculate days until due date
+  days_until_due: 'if(due_date, (date(due_date) - today()).days, "")'
+```
+
+## Key Functions
+
+Most commonly used functions. For the complete reference of all types (Date, String, Number, List, File, Link, Object, RegExp), see [FUNCTIONS_REFERENCE.md](FUNCTIONS_REFERENCE.md).
+
+| Function | Signature | Description |
+|----------|-----------|-------------|
+| `date()` | `date(string): date` | Parse string to date (`YYYY-MM-DD HH:mm:ss`) |
+| `now()` | `now(): date` | Current date and time |
+| `today()` | `today(): date` | Current date (time = 00:00:00) |
+| `if()` | `if(condition, trueResult, falseResult?)` | Conditional |
+| `duration()` | `duration(string): duration` | Parse duration string |
+| `file()` | `file(path): file` | Get file object |
+| `link()` | `link(path, display?): Link` | Create a link |
+
+### Duration Type
+
+When subtracting two dates, the result is a **Duration** type (not a number).
+
+**Duration Fields:** `duration.days`, `duration.hours`, `duration.minutes`, `duration.seconds`, `duration.milliseconds`
+
+**IMPORTANT:** Duration does NOT support `.round()`, `.floor()`, `.ceil()` directly. Access a numeric field first (like `.days`), then apply number functions.
+
+```yaml
+# CORRECT: Calculate days between dates
+"(date(due_date) - today()).days"                    # Returns number of days
+"(now() - file.ctime).days"                          # Days since created
+"(date(due_date) - today()).days.round(0)"           # Rounded days
+
+# WRONG - will cause error:
+# "((date(due) - today()) / 86400000).round(0)"      # Duration doesn't support division then round
+```
+
+### Date Arithmetic
+
+```yaml
+# Duration units: y/year/years, M/month/months, d/day/days,
+#                 w/week/weeks, h/hour/hours, m/minute/minutes, s/second/seconds
+"now() + \"1 day\""       # Tomorrow
+"today() + \"7d\""        # A week from today
+"now() - file.ctime"      # Returns Duration
+"(now() - file.ctime).days"  # Get days as number
+```
+
+## View Types
+
+### Table View
+
+```yaml
+views:
+  - type: table
+    name: "My Table"
+    order:
+      - file.name
+      - status
+      - due_date
+    summaries:
+      price: Sum
+      count: Average
+```
+
+### Cards View
+
+```yaml
+views:
+  - type: cards
+    name: "Gallery"
+    order:
+      - file.name
+      - cover_image
+      - description
+```
+
+### List View
+
+```yaml
+views:
+  - type: list
+    name: "Simple List"
+    order:
+      - file.name
+      - status
+```
+
+### Map View
+
+Requires latitude/longitude properties and the Maps community plugin.
+
+```yaml
+views:
+  - type: map
+    name: "Locations"
+    # Map-specific settings for lat/lng properties
+```
+
+## Default Summary Formulas
+
+| Name | Input Type | Description |
+|------|------------|-------------|
+| `Average` | Number | Mathematical mean |
+| `Min` | Number | Smallest number |
+| `Max` | Number | Largest number |
+| `Sum` | Number | Sum of all numbers |
+| `Range` | Number | Max - Min |
+| `Median` | Number | Mathematical median |
+| `Stddev` | Number | Standard deviation |
+| `Earliest` | Date | Earliest date |
+| `Latest` | Date | Latest date |
+| `Range` | Date | Latest - Earliest |
+| `Checked` | Boolean | Count of true values |
+| `Unchecked` | Boolean | Count of false values |
+| `Empty` | Any | Count of empty values |
+| `Filled` | Any | Count of non-empty values |
+| `Unique` | Any | Count of unique values |
+
+## Complete Examples
+
+### Task Tracker Base
+
+```yaml
+filters:
+  and:
+    - file.hasTag("task")
+    - 'file.ext == "md"'
+
+formulas:
+  days_until_due: 'if(due, (date(due) - today()).days, "")'
+  is_overdue: 'if(due, date(due) < today() && status != "done", false)'
+  priority_label: 'if(priority == 1, "🔴 High", if(priority == 2, "🟡 Medium", "🟢 Low"))'
+
+properties:
+  status:
+    displayName: Status
+  formula.days_until_due:
+    displayName: "Days Until Due"
+  formula.priority_label:
+    displayName: Priority
+
+views:
+  - type: table
+    name: "Active Tasks"
+    filters:
+      and:
+        - 'status != "done"'
+    order:
+      - file.name
+      - status
+      - formula.priority_label
+      - due
+      - formula.days_until_due
+    groupBy:
+      property: status
+      direction: ASC
+    summaries:
+      formula.days_until_due: Average
+
+  - type: table
+    name: "Completed"
+    filters:
+      and:
+        - 'status == "done"'
+    order:
+      - file.name
+      - completed_date
+```
+
+### Reading List Base
+
+```yaml
+filters:
+  or:
+    - file.hasTag("book")
+    - file.hasTag("article")
+
+formulas:
+  reading_time: 'if(pages, (pages * 2).toString() + " min", "")'
+  status_icon: 'if(status == "reading", "📖", if(status == "done", "✅", "📚"))'
+  year_read: 'if(finished_date, date(finished_date).year, "")'
+
+properties:
+  author:
+    displayName: Author
+  formula.status_icon:
+    displayName: ""
+  formula.reading_time:
+    displayName: "Est. Time"
+
+views:
+  - type: cards
+    name: "Library"
+    order:
+      - cover
+      - file.name
+      - author
+      - formula.status_icon
+    filters:
+      not:
+        - 'status == "dropped"'
+
+  - type: table
+    name: "Reading List"
+    filters:
+      and:
+        - 'status == "to-read"'
+    order:
+      - file.name
+      - author
+      - pages
+      - formula.reading_time
+```
+
+### Daily Notes Index
+
+```yaml
+filters:
+  and:
+    - file.inFolder("Daily Notes")
+    - '/^\d{4}-\d{2}-\d{2}$/.matches(file.basename)'
+
+formulas:
+  word_estimate: '(file.size / 5).round(0)'
+  day_of_week: 'date(file.basename).format("dddd")'
+
+properties:
+  formula.day_of_week:
+    displayName: "Day"
+  formula.word_estimate:
+    displayName: "~Words"
+
+views:
+  - type: table
+    name: "Recent Notes"
+    limit: 30
+    order:
+      - file.name
+      - formula.day_of_week
+      - formula.word_estimate
+      - file.mtime
+```
+
+## Embedding Bases
+
+Embed in Markdown files:
+
+```markdown
+![[MyBase.base]]
+
+<!-- Specific view -->
+![[MyBase.base#View Name]]
+```
+
+## YAML Quoting Rules
+
+- Use single quotes for formulas containing double quotes: `'if(done, "Yes", "No")'`
+- Use double quotes for simple strings: `"My View Name"`
+- Escape nested quotes properly in complex expressions
+
+## Troubleshooting
+
+### YAML Syntax Errors
+
+**Unquoted special characters**: Strings containing `:`, `{`, `}`, `[`, `]`, `,`, `&`, `*`, `#`, `?`, `|`, `-`, `<`, `>`, `=`, `!`, `%`, `@`, `` ` `` must be quoted.
+
+```yaml
+# WRONG - colon in unquoted string
+displayName: Status: Active
+
+# CORRECT
+displayName: "Status: Active"
+```
+
+**Mismatched quotes in formulas**: When a formula contains double quotes, wrap the entire formula in single quotes.
+
+```yaml
+# WRONG - double quotes inside double quotes
+formulas:
+  label: "if(done, "Yes", "No")"
+
+# CORRECT - single quotes wrapping double quotes
+formulas:
+  label: 'if(done, "Yes", "No")'
+```
+
+### Common Formula Errors
+
+**Duration math without field access**: Subtracting dates returns a Duration, not a number. Always access `.days`, `.hours`, etc.
+
+```yaml
+# WRONG - Duration is not a number
+"(now() - file.ctime).round(0)"
+
+# CORRECT - access .days first, then round
+"(now() - file.ctime).days.round(0)"
+```
+
+**Missing null checks**: Properties may not exist on all notes. Use `if()` to guard.
+
+```yaml
+# WRONG - crashes if due_date is empty
+"(date(due_date) - today()).days"
+
+# CORRECT - guard with if()
+'if(due_date, (date(due_date) - today()).days, "")'
+```
+
+**Referencing undefined formulas**: Ensure every `formula.X` in `order` or `properties` has a matching entry in `formulas`.
+
+```yaml
+# This will fail silently if 'total' is not defined in formulas
+order:
+  - formula.total
+
+# Fix: define it
+formulas:
+  total: "price * quantity"
+```
+
+## References
+
+- [Bases Syntax](https://help.obsidian.md/bases/syntax)
+- [Functions](https://help.obsidian.md/bases/functions)
+- [Views](https://help.obsidian.md/bases/views)
+- [Formulas](https://help.obsidian.md/formulas)
+- [Complete Functions Reference](FUNCTIONS_REFERENCE.md)

--- a/.apm/skills/obsidian/references/CALLOUTS.md
+++ b/.apm/skills/obsidian/references/CALLOUTS.md
@@ -1,0 +1,58 @@
+# Callouts Reference
+
+## Basic Callout
+
+```markdown
+> [!note]
+> This is a note callout.
+
+> [!info] Custom Title
+> This callout has a custom title.
+
+> [!tip] Title Only
+```
+
+## Foldable Callouts
+
+```markdown
+> [!faq]- Collapsed by default
+> This content is hidden until expanded.
+
+> [!faq]+ Expanded by default
+> This content is visible but can be collapsed.
+```
+
+## Nested Callouts
+
+```markdown
+> [!question] Outer callout
+> > [!note] Inner callout
+> > Nested content
+```
+
+## Supported Callout Types
+
+| Type | Aliases | Color / Icon |
+|------|---------|--------------|
+| `note` | - | Blue, pencil |
+| `abstract` | `summary`, `tldr` | Teal, clipboard |
+| `info` | - | Blue, info |
+| `todo` | - | Blue, checkbox |
+| `tip` | `hint`, `important` | Cyan, flame |
+| `success` | `check`, `done` | Green, checkmark |
+| `question` | `help`, `faq` | Yellow, question mark |
+| `warning` | `caution`, `attention` | Orange, warning |
+| `failure` | `fail`, `missing` | Red, X |
+| `danger` | `error` | Red, zap |
+| `bug` | - | Red, bug |
+| `example` | - | Purple, list |
+| `quote` | `cite` | Gray, quote |
+
+## Custom Callouts (CSS)
+
+```css
+.callout[data-callout="custom-type"] {
+  --callout-color: 255, 0, 0;
+  --callout-icon: lucide-alert-circle;
+}
+```

--- a/.apm/skills/obsidian/references/EMBEDS.md
+++ b/.apm/skills/obsidian/references/EMBEDS.md
@@ -1,0 +1,70 @@
+# Embeds Reference
+
+## Embed Notes
+
+```markdown
+![[Note Name]]
+![[Note Name#Heading]]
+![[Note Name#^block-id]]
+```
+
+## Embed Images
+
+```markdown
+![[image.png]]
+![[image.png|640x480]]    Width x Height
+![[image.png|300]]        Width only (maintains aspect ratio)
+```
+
+## External Images
+
+```markdown
+![Alt text](https://example.com/image.png)
+![Alt text|300](https://example.com/image.png)
+```
+
+## Embed Audio
+
+```markdown
+![[audio.mp3]]
+![[audio.ogg]]
+```
+
+## Embed PDF
+
+```markdown
+![[document.pdf]]
+![[document.pdf#page=3]]
+![[document.pdf#height=400]]
+```
+
+## Embed Bases
+
+```markdown
+![[BaseFile.base]]
+![[BaseFile.base#View Name]]
+```
+
+## Embed Lists
+
+```markdown
+![[Note#^list-id]]
+```
+
+Where the list has a block ID:
+
+```markdown
+- Item 1
+- Item 2
+- Item 3
+
+^list-id
+```
+
+## Embed Search Results
+
+````markdown
+```query
+tag:#project status:done
+```
+````

--- a/.apm/skills/obsidian/references/FUNCTIONS_REFERENCE.md
+++ b/.apm/skills/obsidian/references/FUNCTIONS_REFERENCE.md
@@ -1,0 +1,173 @@
+# Functions Reference
+
+## Global Functions
+
+| Function | Signature | Description |
+|----------|-----------|-------------|
+| `date()` | `date(string): date` | Parse string to date. Format: `YYYY-MM-DD HH:mm:ss` |
+| `duration()` | `duration(string): duration` | Parse duration string |
+| `now()` | `now(): date` | Current date and time |
+| `today()` | `today(): date` | Current date (time = 00:00:00) |
+| `if()` | `if(condition, trueResult, falseResult?)` | Conditional |
+| `min()` | `min(n1, n2, ...): number` | Smallest number |
+| `max()` | `max(n1, n2, ...): number` | Largest number |
+| `number()` | `number(any): number` | Convert to number |
+| `link()` | `link(path, display?): Link` | Create a link |
+| `list()` | `list(element): List` | Wrap in list if not already |
+| `file()` | `file(path): file` | Get file object |
+| `image()` | `image(path): image` | Create image for rendering |
+| `icon()` | `icon(name): icon` | Lucide icon by name |
+| `html()` | `html(string): html` | Render as HTML |
+| `escapeHTML()` | `escapeHTML(string): string` | Escape HTML characters |
+
+## Any Type Functions
+
+| Function | Signature | Description |
+|----------|-----------|-------------|
+| `isTruthy()` | `any.isTruthy(): boolean` | Coerce to boolean |
+| `isType()` | `any.isType(type): boolean` | Check type |
+| `toString()` | `any.toString(): string` | Convert to string |
+
+## Date Functions & Fields
+
+**Fields:** `date.year`, `date.month`, `date.day`, `date.hour`, `date.minute`, `date.second`, `date.millisecond`
+
+| Function | Signature | Description |
+|----------|-----------|-------------|
+| `date()` | `date.date(): date` | Remove time portion |
+| `format()` | `date.format(string): string` | Format with Moment.js pattern |
+| `time()` | `date.time(): string` | Get time as string |
+| `relative()` | `date.relative(): string` | Human-readable relative time |
+| `isEmpty()` | `date.isEmpty(): boolean` | Always false for dates |
+
+## Duration Type
+
+When subtracting two dates, the result is a **Duration** type (not a number). Duration has its own properties and methods.
+
+**Duration Fields:**
+| Field | Type | Description |
+|-------|------|-------------|
+| `duration.days` | Number | Total days in duration |
+| `duration.hours` | Number | Total hours in duration |
+| `duration.minutes` | Number | Total minutes in duration |
+| `duration.seconds` | Number | Total seconds in duration |
+| `duration.milliseconds` | Number | Total milliseconds in duration |
+
+**IMPORTANT:** Duration does NOT support `.round()`, `.floor()`, `.ceil()` directly. You must access a numeric field first (like `.days`), then apply number functions.
+
+```yaml
+# CORRECT: Calculate days between dates
+"(date(due_date) - today()).days"                    # Returns number of days
+"(now() - file.ctime).days"                          # Days since created
+
+# CORRECT: Round the numeric result if needed
+"(date(due_date) - today()).days.round(0)"           # Rounded days
+"(now() - file.ctime).hours.round(0)"                # Rounded hours
+
+# WRONG - will cause error:
+# "((date(due) - today()) / 86400000).round(0)"      # Duration doesn't support division then round
+```
+
+## Date Arithmetic
+
+```yaml
+# Duration units: y/year/years, M/month/months, d/day/days,
+#                 w/week/weeks, h/hour/hours, m/minute/minutes, s/second/seconds
+
+# Add/subtract durations
+"date + \"1M\""           # Add 1 month
+"date - \"2h\""           # Subtract 2 hours
+"now() + \"1 day\""       # Tomorrow
+"today() + \"7d\""        # A week from today
+
+# Subtract dates returns Duration type
+"now() - file.ctime"                    # Returns Duration
+"(now() - file.ctime).days"             # Get days as number
+"(now() - file.ctime).hours"            # Get hours as number
+
+# Complex duration arithmetic
+"now() + (duration('1d') * 2)"
+```
+
+## String Functions
+
+**Field:** `string.length`
+
+| Function | Signature | Description |
+|----------|-----------|-------------|
+| `contains()` | `string.contains(value): boolean` | Check substring |
+| `containsAll()` | `string.containsAll(...values): boolean` | All substrings present |
+| `containsAny()` | `string.containsAny(...values): boolean` | Any substring present |
+| `startsWith()` | `string.startsWith(query): boolean` | Starts with query |
+| `endsWith()` | `string.endsWith(query): boolean` | Ends with query |
+| `isEmpty()` | `string.isEmpty(): boolean` | Empty or not present |
+| `lower()` | `string.lower(): string` | To lowercase |
+| `title()` | `string.title(): string` | To Title Case |
+| `trim()` | `string.trim(): string` | Remove whitespace |
+| `replace()` | `string.replace(pattern, replacement): string` | Replace pattern |
+| `repeat()` | `string.repeat(count): string` | Repeat string |
+| `reverse()` | `string.reverse(): string` | Reverse string |
+| `slice()` | `string.slice(start, end?): string` | Substring |
+| `split()` | `string.split(separator, n?): list` | Split to list |
+
+## Number Functions
+
+| Function | Signature | Description |
+|----------|-----------|-------------|
+| `abs()` | `number.abs(): number` | Absolute value |
+| `ceil()` | `number.ceil(): number` | Round up |
+| `floor()` | `number.floor(): number` | Round down |
+| `round()` | `number.round(digits?): number` | Round to digits |
+| `toFixed()` | `number.toFixed(precision): string` | Fixed-point notation |
+| `isEmpty()` | `number.isEmpty(): boolean` | Not present |
+
+## List Functions
+
+**Field:** `list.length`
+
+| Function | Signature | Description |
+|----------|-----------|-------------|
+| `contains()` | `list.contains(value): boolean` | Element exists |
+| `containsAll()` | `list.containsAll(...values): boolean` | All elements exist |
+| `containsAny()` | `list.containsAny(...values): boolean` | Any element exists |
+| `filter()` | `list.filter(expression): list` | Filter by condition (uses `value`, `index`) |
+| `map()` | `list.map(expression): list` | Transform elements (uses `value`, `index`) |
+| `reduce()` | `list.reduce(expression, initial): any` | Reduce to single value (uses `value`, `index`, `acc`) |
+| `flat()` | `list.flat(): list` | Flatten nested lists |
+| `join()` | `list.join(separator): string` | Join to string |
+| `reverse()` | `list.reverse(): list` | Reverse order |
+| `slice()` | `list.slice(start, end?): list` | Sublist |
+| `sort()` | `list.sort(): list` | Sort ascending |
+| `unique()` | `list.unique(): list` | Remove duplicates |
+| `isEmpty()` | `list.isEmpty(): boolean` | No elements |
+
+## File Functions
+
+| Function | Signature | Description |
+|----------|-----------|-------------|
+| `asLink()` | `file.asLink(display?): Link` | Convert to link |
+| `hasLink()` | `file.hasLink(otherFile): boolean` | Has link to file |
+| `hasTag()` | `file.hasTag(...tags): boolean` | Has any of the tags |
+| `hasProperty()` | `file.hasProperty(name): boolean` | Has property |
+| `inFolder()` | `file.inFolder(folder): boolean` | In folder or subfolder |
+
+## Link Functions
+
+| Function | Signature | Description |
+|----------|-----------|-------------|
+| `asFile()` | `link.asFile(): file` | Get file object |
+| `linksTo()` | `link.linksTo(file): boolean` | Links to file |
+
+## Object Functions
+
+| Function | Signature | Description |
+|----------|-----------|-------------|
+| `isEmpty()` | `object.isEmpty(): boolean` | No properties |
+| `keys()` | `object.keys(): list` | List of keys |
+| `values()` | `object.values(): list` | List of values |
+
+## Regular Expression Functions
+
+| Function | Signature | Description |
+|----------|-----------|-------------|
+| `matches()` | `regexp.matches(string): boolean` | Test if matches |

--- a/.apm/skills/obsidian/references/PROPERTIES.md
+++ b/.apm/skills/obsidian/references/PROPERTIES.md
@@ -1,0 +1,62 @@
+# Properties (Frontmatter) Reference
+
+Properties use YAML frontmatter at the start of a note:
+
+```yaml
+---
+title: My Note Title
+date: 2024-01-15
+tags:
+  - project
+  - important
+aliases:
+  - My Note
+  - Alternative Name
+cssclasses:
+  - custom-class
+status: in-progress
+rating: 4.5
+completed: false
+due: 2024-02-01T14:30:00
+---
+```
+
+## Property Types
+
+| Type | Example |
+|------|---------|
+| Text | `title: My Title` |
+| Number | `rating: 4.5` |
+| Checkbox | `completed: true` |
+| Date | `date: 2024-01-15` |
+| Date & Time | `due: 2024-01-15T14:30:00` |
+| List | `tags: [one, two]` or YAML list |
+| Links | `related: "[[Other Note]]"` |
+
+## Default Properties
+
+- `tags` - Note tags (searchable, shown in graph view)
+- `aliases` - Alternative names for the note (used in link suggestions)
+- `cssclasses` - CSS classes applied to the note in reading/editing view
+
+## Tags
+
+```markdown
+#tag
+#nested/tag
+#tag-with-dashes
+#tag_with_underscores
+```
+
+Tags can contain: letters (any language), numbers (not first character),
+underscores `_`, hyphens `-`, forward slashes `/` (for nesting).
+
+In frontmatter:
+
+```yaml
+---
+tags:
+  - tag1
+  - nested/tag2
+---
+```

--- a/INDEX.md
+++ b/INDEX.md
@@ -31,6 +31,7 @@
 - **[Inbox Triage Pass](/.apm/skills/inbox-triage-pass/SKILL.md)** - |
 - **[Meeting Transcript Creation](/.apm/skills/meeting-transcript-creation/SKILL.md)** - |
 - **[Morning Briefing](/.apm/skills/morning-briefing/SKILL.md)** - |
+- **[Obsidian](/.apm/skills/obsidian/SKILL.md)** - Create and edit Obsidian content -- Obsidian Flavored Markdown (wikilinks, embeds, callouts, properties, tags) and Bases (.base database views with filters, formulas, and summaries). Use when working with Obsidian notes or .base files, or when the user mentions wikilinks, callouts, frontmatter, tags, embeds, Bases, table/card views, filters, or formulas in Obsidian.
 - **[Ooo Task Handoff Planner](/.apm/skills/ooo-task-handoff-planner/SKILL.md)** - |
 
 ## 🧑‍✈️ Agents
@@ -45,19 +46,19 @@
 
 > External agents pulled via APM dependencies, committed here as a reviewable snapshot (see `apm.yml`)
 
-- **[Accessibility Expert](/.github/agents/accessibility.agent.md)** - Expert assistant for web accessibility (WCAG 2.1/2.2), inclusive UX, and a11y testing
-- **[ADR Generator](/.github/agents/adr-generator.agent.md)** - Expert agent for creating comprehensive Architectural Decision Records (ADRs) with structured formatting optimized for AI consumption and human readability.
-- **[DevOps Expert](/.github/agents/devops-expert.agent.md)** - DevOps specialist following the infinity loop principle (Plan → Code → Build → Test → Release → Deploy → Operate → Monitor) with focus on automation, collaboration, and continuous improvement
-- **[GitHub Actions Expert](/.github/agents/github-actions-expert.agent.md)** - GitHub Actions specialist focused on secure CI/CD workflows, action pinning, OIDC authentication, permissions least privilege, and supply-chain security
-- **[LinkedIn Post Writer](/.github/agents/linkedin-post-writer.agent.md)** - Draft and format compelling LinkedIn posts with Unicode bold/italic styling, visual separators, and engagement-optimized structure. Transforms raw content, technical material, images, or ideas into copy-paste-ready LinkedIn posts.
-- **[Project Architecture Planner](/.github/agents/project-architecture-planner.agent.md)** - Holistic software architecture planner that evaluates tech stacks, designs scalability roadmaps, performs cloud-agnostic cost analysis, reviews existing codebases, and delivers interactive Mermaid diagrams with HTML preview and draw.io export
-- **[Prompt Builder](/.github/agents/prompt-builder.agent.md)** - Expert prompt engineering and validation system for creating high-quality prompts - Brought to you by microsoft/edge-ai
-- **[sast-sca-security-analyzer](/.github/agents/sast-sca-security-analyzer.agent.md)** - Use when: performing SAST (Static Application Security Testing), SCA (Software Composition Analysis), scanning source code or binaries for security flaws, auditing third-party dependency vulnerabilities, checking policy compliance, generating structured security reports, identifying CWE-mapped flaws with file/line precision, reviewing open-source license risk, or producing CI/CD-gate security findings.
-- **[SE: Security](/.github/agents/se-security-reviewer.agent.md)** - Security-focused code review specialist with OWASP Top 10, Zero Trust, LLM security, and enterprise security standards
-- **[SE: Tech Writer](/.github/agents/se-technical-writer.agent.md)** - Technical writing specialist for creating developer documentation, technical blogs, tutorials, and educational content
-- **[SE: UX Designer](/.github/agents/se-ux-ui-designer.agent.md)** - Jobs-to-be-Done analysis, user journey mapping, and UX research artifacts for Figma and design workflows
-- **[Software Engineer Agent](/.github/agents/software-engineer-agent-v1.agent.md)** - Expert-level software engineering agent. Deliver production-ready, maintainable code. Execute systematically and specification-driven. Document comprehensively. Operate autonomously and adaptively.
-- **[Task Planner Instructions](/.github/agents/task-planner.agent.md)** - Task planner for creating actionable implementation plans - Brought to you by microsoft/edge-ai
+- **[Accessibility](/.github/agents/accessibility.agent.md)** - 
+- **[Adr Generator](/.github/agents/adr-generator.agent.md)** - 
+- **[Devops Expert](/.github/agents/devops-expert.agent.md)** - 
+- **[Github Actions Expert](/.github/agents/github-actions-expert.agent.md)** - 
+- **[Linkedin Post Writer](/.github/agents/linkedin-post-writer.agent.md)** - 
+- **[Project Architecture Planner](/.github/agents/project-architecture-planner.agent.md)** - 
+- **[Prompt Builder](/.github/agents/prompt-builder.agent.md)** - 
+- **[Sast Sca Security Analyzer](/.github/agents/sast-sca-security-analyzer.agent.md)** - 
+- **[Se Security Reviewer](/.github/agents/se-security-reviewer.agent.md)** - 
+- **[Se Technical Writer](/.github/agents/se-technical-writer.agent.md)** - 
+- **[Se Ux Ui Designer](/.github/agents/se-ux-ui-designer.agent.md)** - 
+- **[Software Engineer Agent V1](/.github/agents/software-engineer-agent-v1.agent.md)** - 
+- **[Task Planner](/.github/agents/task-planner.agent.md)** - 
 
 ## 🤖 GitHub Copilot Prompts
 

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ That committed snapshot is a **review gate**: bumping a dependency (`apm update`
 - **[Inbox Triage Pass](/.apm/skills/inbox-triage-pass/SKILL.md)** - |
 - **[Meeting Transcript Creation](/.apm/skills/meeting-transcript-creation/SKILL.md)** - |
 - **[Morning Briefing](/.apm/skills/morning-briefing/SKILL.md)** - |
+- **[Obsidian](/.apm/skills/obsidian/SKILL.md)** - Create and edit Obsidian content -- Obsidian Flavored Markdown (wikilinks, embeds, callouts, properties, tags) and Bases (.base database views with filters, formulas, and summaries). Use when working with Obsidian notes or .base files, or when the user mentions wikilinks, callouts, frontmatter, tags, embeds, Bases, table/card views, filters, or formulas in Obsidian.
 - **[Ooo Task Handoff Planner](/.apm/skills/ooo-task-handoff-planner/SKILL.md)** - |
 
 ## 🧑‍✈️ Agents
@@ -64,19 +65,19 @@ That committed snapshot is a **review gate**: bumping a dependency (`apm update`
 
 > External agents pulled via APM dependencies, committed here as a reviewable snapshot (see `apm.yml`)
 
-- **[Accessibility Expert](/.github/agents/accessibility.agent.md)** - Expert assistant for web accessibility (WCAG 2.1/2.2), inclusive UX, and a11y testing
-- **[ADR Generator](/.github/agents/adr-generator.agent.md)** - Expert agent for creating comprehensive Architectural Decision Records (ADRs) with structured formatting optimized for AI consumption and human readability.
-- **[DevOps Expert](/.github/agents/devops-expert.agent.md)** - DevOps specialist following the infinity loop principle (Plan → Code → Build → Test → Release → Deploy → Operate → Monitor) with focus on automation, collaboration, and continuous improvement
-- **[GitHub Actions Expert](/.github/agents/github-actions-expert.agent.md)** - GitHub Actions specialist focused on secure CI/CD workflows, action pinning, OIDC authentication, permissions least privilege, and supply-chain security
-- **[LinkedIn Post Writer](/.github/agents/linkedin-post-writer.agent.md)** - Draft and format compelling LinkedIn posts with Unicode bold/italic styling, visual separators, and engagement-optimized structure. Transforms raw content, technical material, images, or ideas into copy-paste-ready LinkedIn posts.
-- **[Project Architecture Planner](/.github/agents/project-architecture-planner.agent.md)** - Holistic software architecture planner that evaluates tech stacks, designs scalability roadmaps, performs cloud-agnostic cost analysis, reviews existing codebases, and delivers interactive Mermaid diagrams with HTML preview and draw.io export
-- **[Prompt Builder](/.github/agents/prompt-builder.agent.md)** - Expert prompt engineering and validation system for creating high-quality prompts - Brought to you by microsoft/edge-ai
-- **[sast-sca-security-analyzer](/.github/agents/sast-sca-security-analyzer.agent.md)** - Use when: performing SAST (Static Application Security Testing), SCA (Software Composition Analysis), scanning source code or binaries for security flaws, auditing third-party dependency vulnerabilities, checking policy compliance, generating structured security reports, identifying CWE-mapped flaws with file/line precision, reviewing open-source license risk, or producing CI/CD-gate security findings.
-- **[SE: Security](/.github/agents/se-security-reviewer.agent.md)** - Security-focused code review specialist with OWASP Top 10, Zero Trust, LLM security, and enterprise security standards
-- **[SE: Tech Writer](/.github/agents/se-technical-writer.agent.md)** - Technical writing specialist for creating developer documentation, technical blogs, tutorials, and educational content
-- **[SE: UX Designer](/.github/agents/se-ux-ui-designer.agent.md)** - Jobs-to-be-Done analysis, user journey mapping, and UX research artifacts for Figma and design workflows
-- **[Software Engineer Agent](/.github/agents/software-engineer-agent-v1.agent.md)** - Expert-level software engineering agent. Deliver production-ready, maintainable code. Execute systematically and specification-driven. Document comprehensively. Operate autonomously and adaptively.
-- **[Task Planner Instructions](/.github/agents/task-planner.agent.md)** - Task planner for creating actionable implementation plans - Brought to you by microsoft/edge-ai
+- **[Accessibility](/.github/agents/accessibility.agent.md)** - 
+- **[Adr Generator](/.github/agents/adr-generator.agent.md)** - 
+- **[Devops Expert](/.github/agents/devops-expert.agent.md)** - 
+- **[Github Actions Expert](/.github/agents/github-actions-expert.agent.md)** - 
+- **[Linkedin Post Writer](/.github/agents/linkedin-post-writer.agent.md)** - 
+- **[Project Architecture Planner](/.github/agents/project-architecture-planner.agent.md)** - 
+- **[Prompt Builder](/.github/agents/prompt-builder.agent.md)** - 
+- **[Sast Sca Security Analyzer](/.github/agents/sast-sca-security-analyzer.agent.md)** - 
+- **[Se Security Reviewer](/.github/agents/se-security-reviewer.agent.md)** - 
+- **[Se Technical Writer](/.github/agents/se-technical-writer.agent.md)** - 
+- **[Se Ux Ui Designer](/.github/agents/se-ux-ui-designer.agent.md)** - 
+- **[Software Engineer Agent V1](/.github/agents/software-engineer-agent-v1.agent.md)** - 
+- **[Task Planner](/.github/agents/task-planner.agent.md)** - 
 
 ## 🤖 GitHub Copilot Prompts
 

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -1,0 +1,18 @@
+# Third-Party Notices
+
+This repository bundles content from third-party projects. Each entry below is
+redistributed under its own license, which is retained alongside the bundled
+files. This file is a convenience index — the authoritative license text travels
+with each bundled component.
+
+## obsidian skill
+
+- **Source:** [kepano/obsidian-skills](https://github.com/kepano/obsidian-skills) (the `obsidian-markdown` and `obsidian-bases` skills)
+- **Copyright:** © 2026 Steph Ango (@kepano)
+- **License:** MIT
+- **Bundled at:** [`.apm/skills/obsidian/`](.apm/skills/obsidian/)
+- **License text:** [`.apm/skills/obsidian/LICENSE`](.apm/skills/obsidian/LICENSE)
+
+The `obsidian` skill (`SKILL.md` and its `references/`, including `BASES.md` and
+`FUNCTIONS_REFERENCE.md`) is adapted from the upstream `obsidian-markdown` and
+`obsidian-bases` skills and redistributed under the MIT License.


### PR DESCRIPTION
## What

Adds a single **`obsidian`** skill to the toolkit, consolidating Obsidian Flavored
Markdown and Obsidian Bases into one model-invoked primitive.

- [`.apm/skills/obsidian/SKILL.md`](.apm/skills/obsidian/SKILL.md) — Obsidian
  Flavored Markdown (wikilinks, embeds, callouts, properties, tags, comments,
  math, Mermaid, footnotes) plus a Bases section.
- `references/` — progressive-disclosure detail: `CALLOUTS.md`, `EMBEDS.md`,
  `PROPERTIES.md`, `BASES.md` (full `.base` syntax), `FUNCTIONS_REFERENCE.md`.

## Attribution / licensing

Content is adapted from [kepano/obsidian-skills](https://github.com/kepano/obsidian-skills)
(the `obsidian-markdown` and `obsidian-bases` skills), © 2026 Steph Ango
(@kepano), MIT-licensed. To comply with MIT:

- The upstream MIT notice is bundled in
  [`.apm/skills/obsidian/LICENSE`](.apm/skills/obsidian/LICENSE) so it travels
  with every `apm install`.
- `SKILL.md` carries a `Credits & License` section.
- A top-level [`THIRD_PARTY_NOTICES.md`](THIRD_PARTY_NOTICES.md) catalogs the
  bundled content.

## Notes

- `INDEX.md` / `README.md` regenerated from `.apm/`.
- `bash tests/validate-prompts.sh` passes; pre-commit gate (lefthook) green.
- Files normalized to LF.
