### PR TITLE
docs(conventions): use latest stable package versions

### DIFF
--- a/.apm/instructions/devsecninja-conventions.instructions.md
+++ b/.apm/instructions/devsecninja-conventions.instructions.md
@@ -65,6 +65,9 @@ and prefer reuse over duplication.
   applicable so Renovate can bump it.
 - Reusable workflows in `DevSecNinja/.github` MUST NOT default package/tool
   version inputs — declare them `required: true` so the caller owns the version.
+- Dependencies: when adding or updating a package, check for and use the latest
+  stable release rather than scaffolding on — or leaving deps at — outdated
+  versions. Let Renovate keep them current thereafter.
 - Security: never commit plaintext secrets. Use SOPS, Vault, or GitHub Secrets.
 
 ## Tooling and files


### PR DESCRIPTION
Adds a coding-standards convention: when adding or updating a package, check for and use the latest stable release rather than scaffolding on (or leaving dependencies at) outdated versions. Renovate keeps them current thereafter.

Motivation: a recent project was built on very old package versions (Azure SDK, Functions Worker, Microsoft.Extensions.*), which later required a batch of major upgrades. This rule would have surfaced that at authoring time.

Docs-only: a single bullet added under "Coding standards" in `.apm/instructions/devsecninja-conventions.instructions.md`.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
