### PR TITLE
docs(conventions): prefer trusted first-party dependency sources

### DIFF
--- a/.apm/instructions/devsecninja-conventions.instructions.md
+++ b/.apm/instructions/devsecninja-conventions.instructions.md
@@ -68,6 +68,11 @@ and prefer reuse over duplication.
 - Dependencies: when adding or updating a package, check for and use the latest
   stable release rather than scaffolding on — or leaving deps at — outdated
   versions. Let Renovate keep them current thereafter.
+- Dependency provenance: prefer first-party/official sources (the vendor's own
+  package or feed) over third-party or community-maintained wrappers. Before
+  introducing a community-owned package, devcontainer feature, or action,
+  evaluate its trustworthiness (maintainer, adoption, activity); when in doubt,
+  install from the official source (e.g. via a script) instead.
 - Security: never commit plaintext secrets. Use SOPS, Vault, or GitHub Secrets.
 
 ## Tooling and files


### PR DESCRIPTION
Adds a dependency-provenance convention under "Coding standards": prefer first-party/official sources (the vendor's own package or feed) over third-party or community-maintained wrappers, and vet community-owned packages, devcontainer features, and actions (maintainer, adoption, activity) before introducing them; when in doubt, install from the official source.

Motivation: we replaced a community-owned devcontainer feature (unknown maintainer) with an install from Microsoft's official package feed. This rule captures that supply-chain-hygiene expectation org-wide.

Docs-only: one bullet added to `.apm/instructions/devsecninja-conventions.instructions.md`.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
