### PR TITLE
docs(conventions): require precise, Renovate-managed version pinning

### DIFF
--- a/.apm/instructions/devsecninja-conventions.instructions.md
+++ b/.apm/instructions/devsecninja-conventions.instructions.md
@@ -73,6 +73,11 @@ and prefer reuse over duplication.
   introducing a community-owned package, devcontainer feature, or action,
   evaluate its trustworthiness (maintainer, adoption, activity); when in doubt,
   install from the official source (e.g. via a script) instead.
+- Pin versions precisely: pin every external dependency, tool, and action to an
+  exact version — prefer a full commit SHA where the ecosystem supports it (e.g.
+  GitHub Actions) — and let Renovate manage the bumps. Avoid floating refs like
+  `latest`, `main`, or unpinned ranges. Consuming repos pin the tool versions
+  they use (e.g. in `mise.toml`) rather than relying on a central default.
 - Security: never commit plaintext secrets. Use SOPS, Vault, or GitHub Secrets.
 
 ## Tooling and files


### PR DESCRIPTION
Adds a coding-standards convention on version pinning: pin every dependency, tool, and action to an exact version (prefer a commit SHA where supported, e.g. GitHub Actions), let Renovate manage the bumps, and avoid floating refs like `latest`/`main`. Consuming repos pin the tool versions they use (e.g. in `mise.toml`) rather than relying on a central default.

Motivation: reinforces that shared/central workflows shouldn't own tool versions (the caller does), and that unpinned refs like `@latest` are not acceptable.

Docs-only: one bullet added to `.apm/instructions/devsecninja-conventions.instructions.md`.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
