### PR TITLE
feat: add writing-style instruction to curb AI tells

### DIFF
--- a/.apm/instructions/writing-style.instructions.md
+++ b/.apm/instructions/writing-style.instructions.md
@@ -1,0 +1,38 @@
+---
+description: "Human-facing writing style for AI agents: avoid AI tells like 'So' sentence openers and em-dash/spaced-hyphen pauses, and default to a restrained, low-emoji tone."
+applyTo: "**"
+---
+
+# Writing Style
+
+Rules for **human-facing prose** that an agent writes or drafts: LinkedIn and
+social posts, documentation, commit and PR descriptions, emails, chat messages,
+and any narrative reply to the user. They do not change code, identifiers, or
+literal content the user asked to keep verbatim.
+
+The goal is writing that reads as if a person wrote it, not a language model.
+Several common patterns are dead giveaways of AI-generated text; avoid them.
+
+## Avoid these AI tells
+
+- **No "So" (or "So,") as a sentence opener.** Start the sentence with its
+  actual subject. "So I built one." becomes "I built one."
+- **No em-dashes or spaced-hyphen pauses as connectors.** An em-dash (`—`) or a
+  space-hyphen-space used to tack on a clause or a dramatic pause reads as
+  machine-written. Rework into clean sentences, or use a comma, colon, or full
+  stop instead.
+  - Fine to keep: hyphens inside compound words (`enterprise-ready`,
+    `start-stop`, `maintenance-only`) and in code, cron, or tag examples.
+  - Not fine: "I wanted both — driven by tags." Prefer "I wanted both, driven
+    by tags." or two sentences.
+- **Restrained, low-emoji tone by default.** Skip over-the-top, emoji-filled
+  copy unless the user explicitly asks for it. Prefer at most one or two emoji,
+  or none. Let the substance carry the post.
+
+## General guidance
+
+- Lead with the concrete point, not throat-clearing ("In today's fast-paced
+  world…", "I'm excited to share…").
+- Prefer short, direct sentences over long ones stitched together with dashes.
+- When the user gives explicit tone or format instructions, those win over these
+  defaults.

--- a/INDEX.md
+++ b/INDEX.md
@@ -18,6 +18,7 @@
 > Long-lived behavior rules deployed to each harness's instruction directory
 
 - **[Devsecninja Conventions](/.apm/instructions/devsecninja-conventions.instructions.md)** (`**`) - DevSecNinja org-wide engineering conventions for AI agents: Conventional-Commit PR titles, pre-PR checks, docs, and no force-push.
+- **[Writing Style](/.apm/instructions/writing-style.instructions.md)** (`**`) - Human-facing writing style for AI agents: avoid AI tells like 'So' sentence openers and em-dash/spaced-hyphen pauses, and default to a restrained, low-emoji tone.
 
 ## 🧠 Skills
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ That committed snapshot is a **review gate**: bumping a dependency (`apm update`
 > Long-lived behavior rules deployed to each harness's instruction directory
 
 - **[Devsecninja Conventions](/.apm/instructions/devsecninja-conventions.instructions.md)** (`**`) - DevSecNinja org-wide engineering conventions for AI agents: Conventional-Commit PR titles, pre-PR checks, docs, and no force-push.
+- **[Writing Style](/.apm/instructions/writing-style.instructions.md)** (`**`) - Human-facing writing style for AI agents: avoid AI tells like 'So' sentence openers and em-dash/spaced-hyphen pauses, and default to a restrained, low-emoji tone.
 
 ## 🧠 Skills
 


### PR DESCRIPTION
## What

Adds a new APM instruction primitive `.apm/instructions/writing-style.instructions.md` (`applyTo: "**"`) that steers **human-facing prose** written by agents away from common AI giveaways and toward a more natural, restrained voice.

The learnings came from iterating on a LinkedIn post with the (upstream) LinkedIn Post Writer agent. Since that agent is a SHA-pinned `awesome-copilot` dependency (its `.github/agents/` copy is a regenerated snapshot), the durable place to encode style guidance is a locally authored `.apm/` instruction that applies across all agents, rather than an edit to the bundled agent file.

## Rules encoded

- **No "So" (or "So,") as a sentence opener.**
- **No em-dashes or spaced-hyphen pauses as connectors** (compound hyphens like `enterprise-ready` and code/cron/tag examples are fine).
- **Restrained, low-emoji tone by default**: no over-the-top, emoji-filled copy unless explicitly requested.
- Minor general guidance: lead with the point, avoid throat-clearing, prefer short direct sentences.

## Also

- Regenerated `INDEX.md` and the README index block (`scripts/generate-index.sh`).

## Notes

- `.apm/` is the source of truth; the instruction deploys per harness on `apm install` (git-ignored), so no `.github/` snapshot is committed here.
- Local `validate-prompts` and `commit-msg` hooks could not run on the macOS default bash 3.2 (no `globstar`); the file passes the actual validation logic (frontmatter + `description` + `applyTo` + non-empty body) and the commit message is Conventional. Linux CI runs both cleanly.
