### PR TITLE
chore(config-sync): exclude renovate.json5 from central sync

### DIFF
--- a/.github/.config-sync-ignore
+++ b/.github/.config-sync-ignore
@@ -1,0 +1,6 @@
+# Paths (relative to repo root) excluded from central config sync.
+# One path per line. Blank lines and `#` comments are allowed.
+
+# Renovate config is managed locally (extends the shared DevSecNinja/.github
+# preset); do not let config-sync overwrite it.
+renovate.json5


### PR DESCRIPTION
## What

Adds `.github/.config-sync-ignore` with `renovate.json5` so the central config-sync workflow stops overwriting the local Renovate config.

## Why

`renovate.json5` is managed locally (it extends the shared `github>DevSecNinja/.github` preset). PR #45 showed config-sync trying to overwrite it, dropping local customizations. This opt-out (documented in the config-sync workflow) prevents that.

## Follow-up

PR #45 can be closed without merging.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>