### PR TITLE
feat(hooks): require human approval before git push

### DIFF
--- a/.apm/hooks/git-push-approval.json
+++ b/.apm/hooks/git-push-approval.json
@@ -1,0 +1,13 @@
+{
+  "version": 1,
+  "hooks": {
+    "preToolUse": [
+      {
+        "type": "command",
+        "bash": "${PLUGIN_ROOT}/scripts/git-push-approval/require-push-approval.sh",
+        "cwd": ".",
+        "timeoutSec": 10
+      }
+    ]
+  }
+}

--- a/scripts/git-push-approval/require-push-approval.sh
+++ b/scripts/git-push-approval/require-push-approval.sh
@@ -1,0 +1,89 @@
+#!/bin/bash
+
+# Git Push Approval Hook
+# Forces an explicit, interactive human approval before the AI coding agent runs
+# any `git push`. A commit is entirely local and rewritable (amend / reset /
+# rebase) until it is pushed, so `git push` is the first irreversible step that
+# publishes work to a remote — the right place for a human checkpoint.
+#
+# Runs as a Copilot `preToolUse` command hook. It reads the tool invocation as
+# JSON on stdin and, when the tool is a shell command that contains a `git push`,
+# emits a `permissionDecision: "ask"` object so the CLI prompts the user to
+# approve. For every other tool call it emits no decision and lets the normal
+# permission flow proceed.
+#
+# IMPORTANT: `preToolUse` command hooks are fail-closed — a non-zero exit (or a
+# crash) denies the tool call. This script therefore always exits 0 and only
+# ever upgrades the decision to "ask"; it never blocks unrelated tools.
+#
+# Environment variables:
+#   SKIP_PUSH_APPROVAL - "true" to disable the guardrail entirely (default: unset)
+#
+# See docs: https://docs.github.com/en/copilot/reference/hooks-reference
+
+set -uo pipefail
+
+# Escape hatch: allow operators to turn the guardrail off for a session.
+if [[ "${SKIP_PUSH_APPROVAL:-}" == "true" ]]; then
+    exit 0
+fi
+
+# Read the tool invocation payload from stdin.
+INPUT="$(cat)"
+
+# Extract the tool name and its arguments, tolerating both the camelCase payload
+# (toolName / toolArgs) and the VS Code compatible payload (tool_name / tool_input).
+TOOL_NAME=""
+TOOL_ARGS=""
+
+if command -v jq &>/dev/null; then
+    TOOL_NAME="$(printf '%s' "${INPUT}" | jq -r '.toolName // .tool_name // empty' 2>/dev/null || printf '')"
+    TOOL_ARGS="$(printf '%s' "${INPUT}" | jq -r '
+        (.toolArgs // .tool_input // empty) as $a
+        | if ($a | type) == "string" then $a
+          elif ($a | type) == "object" then ($a.command // $a.cmd // $a.script // ($a | tojson))
+          else ($a | tojson) end' 2>/dev/null || printf '')"
+fi
+
+# Fallback when jq is unavailable or produced nothing: scan the raw payload.
+if [[ -z "${TOOL_NAME}" ]]; then
+    TOOL_NAME="$(printf '%s' "${INPUT}" |
+        grep -oiE '"tool_?[nN]ame"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 |
+        sed -E 's/.*:[[:space:]]*"//; s/"$//' || printf '')"
+fi
+if [[ -z "${TOOL_ARGS}" ]]; then
+    TOOL_ARGS="${INPUT}"
+fi
+
+# Only shell-execution tools can run `git push`. Gate on the tool name so that,
+# for example, editing a document that merely mentions "git push" is unaffected.
+# An empty/unknown tool name falls through to scanning, erring toward asking.
+is_shell_tool() {
+    case "${1,,}" in
+    bash | powershell | shell | "") return 0 ;;
+    *) return 1 ;;
+    esac
+}
+
+# Match `git ... push` within a single command: `git push`, `git push origin main`,
+# `git -C /repo push`, `/usr/bin/git --no-pager push`. Intervening tokens may be
+# flags or values but must not cross a command separator (; & |), so unrelated
+# commands like `git status && npm run push` do not trigger a prompt. The trailing
+# boundary accepts any non-word character (or end of string) so the match still
+# holds when scanning JSON-embedded command text (e.g. `git push"`).
+GIT_PUSH_REGEX='(^|[^[:alnum:]_])git([[:space:]]+[^[:space:];&|]+)*[[:space:]]+push([^[:alnum:]_]|$)'
+
+if is_shell_tool "${TOOL_NAME}" && printf '%s' "${TOOL_ARGS}" | grep -qiE "${GIT_PUSH_REGEX}"; then
+    REASON="git push publishes commits to a remote and is irreversible, unlike local commits (which can still be amended, reset, or rebased). This repository's guardrail requires explicit human approval for every push. Set SKIP_PUSH_APPROVAL=true to disable it."
+    # Emit exactly one decision object. jq keeps the reason safely JSON-escaped;
+    # the printf fallback covers environments without jq.
+    if command -v jq &>/dev/null; then
+        jq -cn --arg reason "${REASON}" '{permissionDecision: "ask", permissionDecisionReason: $reason}'
+    else
+        printf '{"permissionDecision":"ask","permissionDecisionReason":"%s"}\n' \
+            "git push is irreversible and requires explicit human approval. Set SKIP_PUSH_APPROVAL=true to disable."
+    fi
+fi
+
+# Always succeed: fail-closed hooks would otherwise deny unrelated tool calls.
+exit 0


### PR DESCRIPTION
## What

Adds a Copilot `preToolUse` command hook that forces an **explicit, interactive human approval before the agent runs any `git push`**.

- `.apm/hooks/git-push-approval.json` — the hook definition (uses the `bash` command key, like `tool-guardian`).
- `scripts/git-push-approval/require-push-approval.sh` — the guard script.

## Why here (why `git push`?)

A local commit is fully rewritable — `git commit --amend`, `git reset`, `git rebase` all work freely until it's pushed. `git push` is the first **irreversible** step that publishes work to a remote, so it's the correct chokepoint for a human checkpoint.

## How it works

- Reads the tool invocation as JSON on stdin (`toolName`/`toolArgs`, and the VS Code `tool_name`/`tool_input` variant).
- When a **shell** tool (`bash`/`powershell`/`shell`) contains a `git … push`, it emits `{"permissionDecision":"ask", ...}` so the CLI prompts the user to approve. Every other tool call produces no decision and flows through the normal permission path.
- **Always exits 0.** `preToolUse` command hooks are fail-closed (a non-zero exit denies the call), so the script only ever *upgrades* the decision to `ask` and never blocks unrelated tools.
- Detection is scoped to a single command (separators `; & |` break the match), so `git status && npm run push` does **not** prompt; `git push`, `git push origin main`, `git -C /repo push`, and `/usr/bin/git --no-pager push` do.
- `jq` is used when present with a pure-grep/sed fallback when it isn't.

## Design choice: enabled by default

Unlike `tool-guardian` (a heavy blocker shipped with `disableAllHooks`), this hook ships **enabled** — an approval prompt is low-friction and being active is the entire point. Disable per session with `SKIP_PUSH_APPROVAL=true`.

## Validation

- `shellcheck` (repo's strict `.shellcheckrc`) and `shfmt` (per `.editorconfig`): clean.
- `tests/validate-prompts.sh` and `scripts/generate-index.sh`: pass, no index drift (hooks aren't indexed).
- Functional matrix (13 cases): push variants → `ask`; commits, separators, `legit push`, non-shell edits, and the disable switch → allow. Includes a no-`jq` fallback run.

Ref: [Copilot hooks reference](https://docs.github.com/en/copilot/reference/hooks-reference).